### PR TITLE
Re-alphabetize guidelines in each section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A guide for programming in style.
 High level guidelines:
 
 * Be consistent.
-* Don't violate the conventions without a good reason.
 * Don't rewrite existing code to follow this guide.
+* Don't violate the conventions without a good reason.
 
 Heroku
 ------
@@ -19,30 +19,31 @@ Heroku
 Git
 ---
 
+* Avoid including files in source control that are specific to your
+  development machine or process.
+* Delete local and remote feature branches after merging.
 * Perform work in a feature branch.
 * Prefix feature branch names with your initials.
 * Rebase frequently to incorporate upstream changes.
-* Write a [good commit message](http://goo.gl/w11us).
 * Use a [pull request](http://goo.gl/Kmdee) for code reviews.
-* Delete local and remote feature branches after merging.
-* Avoid including files in source control that are specific to your
-  development machine or process.
+* Write a [good commit message](http://goo.gl/w11us).
 
 Formatting
 ----------
 
+* Avoid inline comments.
+* Break long lines after 80 characters.
 * Delete trailing whitespace.
 * Don't include spaces after `(`, `[` or before `]`, `)`.
 * Don't vertically align tokens on consecutive lines.
-* Indent continued lines two spaces.
 * If you break up an argument list, keep the parenthesis on its own line.
 * If you break up a hash, keep the curly braces on their own lines.
+* Indent continued lines two spaces.
 * Indent private methods equal to public methods.
 * Use 2 space indentation (no tabs).
 * Use an empty line between methods.
-* Use spaces around operators, after commas, after colons and semicolons, around `{` and before `}`.
-* Break long lines after 80 characters.
-* Avoid inline comments.
+* Use spaces around operators, after commas, after colons and semicolons, around
+  `{` and before `}`.
 
 Naming
 ------
@@ -76,38 +77,37 @@ Ruby
   instead to emphasize code branches.
 * Define the project's [Ruby version in the
   Gemfile](http://gembundler.com/man/gemfile.5.html#RUBY-ruby-).
-* Prefer `detect` over `find`
-* Prefer `select` over `find_all`
-* Prefer `map` over `collect`
-* Prefer `inject` over `reduce`
-* Use `_` for unused block parameters
+* Prefer `detect` over `find`.
+* Prefer `inject` over `reduce`.
+* Prefer `map` over `collect`.
+* Prefer `select` over `find_all`.
+* Prefer single quotes for strings.
+* Use `_` for unused block parameters.
 * Use `%{}` for single-line strings needing interpolation and double-quotes.
 * Use `&&` and `||` for Boolean expressions.
-* Use `{...}` for single-line blocks.
-* Use `do..end` for multi-line blocks.
+* Use `{...}` for single-line blocks. Use `do..end` for multi-line blocks.
 * Use `?` suffix for predicate methods.
 * Use `CamelCase` for classes and modules, `snake_case` for variables and
   methods, `SCREAMING_SNAKE_CASE` for constants.
+* Use `def self.method`, not `def Class.method` or `class << self`.
 * Use `def` with parentheses when there are arguments.
 * Use `each`, not `for`, for iteration.
 * Use heredocs for multi-line strings.
-* Use `def self.method`, not `def Class.method` or `class << self`.
-* Prefer single quotes for strings.
 
 Rails
 -----
 
-* Avoid the `:except` option in routes.
 * Avoid `member` and `collection` routes.
+* Avoid the `:except` option in routes.
 * Don't reference a model class directly from a view.
+* Don't use protected controller methods.
 * Don't use SQL or SQL fragments (`where('inviter_id is not null')`) outside
   of models.
 * Keep the `db/schema.rb` under version control.
+* If there are default values, set them in migrations.
 * Name initializers for their gem name.
 * Order controller contents: filters, public methods, private methods.
-* Don't use protected controller methods.
 * Order model contents: constants, macros, public methods, private methods.
-* If there are default values, set them in migrations.
 * Use `_path`, not `_url`, for named routes everywhere except mailer views.
 * Use `def self.method`, not the `scope :method` DSL.
 * Use SQL, not `ActiveRecord` models, in migrations.
@@ -132,17 +132,17 @@ Testing
 -------
 
 * Avoid `its`, `let`, `let!`, `specify`, `before`, and `subject`.
+* Avoid using instance variables in tests.
 * Don't prefix `it` block descriptions with 'should'.
 * Name outer `describe` blocks after the method under test. Use `.method`
   for class methods and `#method` for instance methods.
 * Order factories.rb: sequences, traits, factory definitions.
-* Order factory definitions alphabetically by factory name.
 * Order factory attributes: implicit attributes, explicit attributes,
   child factory definitions. Each section's attributes are alphabetical.
-* Use one factories.rb file per project.
+* Order factory definitions alphabetically by factory name.
 * Use an `it` example for each execution path through the method.
+* Use one factories.rb file per project.
 * Use [stubs and spies](http://goo.gl/EciDJ) (not mocks) in isolated tests.
-* Avoid using instance variables in tests.
 
 [Sample](https://github.com/thoughtbot/style-guide/blob/master/rspec-sample.rb)
 


### PR DESCRIPTION
The main reasons to do this are to group like guidelines and use tight language. For example:
- "Avoid" means don't do it unless you have good reason.
- "Don't" means there's never a good reason.
- "Prefer" indicates a better option and its alternative to watch out for.
- "Use" is a positive instruction.
