### PR TITLE
Add to CoffeeScript styleguide

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -73,6 +73,8 @@ CoffeeScript
 * Use `CamelCase` for classes, `lowerCamelCase` for variables and functions,
   `SCREAMING_SNAKE_CASE` for constants, `_single_leading_underscore` for
   private variables and functions.
+* Prefer `is` to `== ` or `===`
+* Prefer `or` and `and` to `||` and `&&`
 
 Ruby
 ----


### PR DESCRIPTION
- Add preference for `or` and `and` in CoffeeScript because they are more CoffeeScripty than `||` and `&&`
- Same for `is` vs `===`
