### PR TITLE
Add project management link to commit message

### DIFF
--- a/protocol/README.md
+++ b/protocol/README.md
@@ -119,6 +119,8 @@ Write a [good commit message](http://goo.gl/w11us).
     * More information about commit (under 72 characters).
     * More information about commit (under 72 characters).
 
+    http://project.management-system.com/ticket/123
+
 Share your branch.
 
     git push origin [branch]


### PR DESCRIPTION
- Create a connection between project management system and git history.
- Make it easy for future developers to understand the reasons why code
  exists without having to disturb the original author or relying on the
  original author being available/on the project/with the company at a
  later date.
