### PR TITLE
Use Newlines around multi-line blocks

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -38,6 +38,7 @@ Formatting
 * Indent private methods equal to public methods.
 * Use 2 space indentation (no tabs).
 * Use an empty line between methods.
+* Use newlines around multi-line blocks.
 * Use spaces around operators, after commas, after colons and semicolons, around
   `{` and before `}`.
 * Use [Unix-style line endings](http://goo.gl/04ehM) (`\n`).


### PR DESCRIPTION
Style update - add newlines around multi-line blocks.

I've seen this done a lot on many projects, but noticed it missing from this repo.

Example:

Before:

```
#...
pandas = Pandas.all
pandas.each do |panda|
  panda.tickle
  panda.output.should eq "Hee hee!"
end
pandas.feed_bamboo
```

```
#...
pandas = Pandas.all

pandas.each do |panda|
  panda.tickle
  panda.output.should eq "Hee hee!"
end

pandas.feed_bamboo
```
