### PR TITLE
Ruby guideline: avoid explicit return statements

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -81,6 +81,7 @@ Ruby
 * Avoid conditional modifiers (lines that end with conditionals).
 * Avoid ternary operators (`boolean ? true : false`). Use multi-line `if`
   instead to emphasize code branches.
+* Avoid explicit return statements.
 * Prefer `detect` over `find`.
 * Prefer `inject` over `reduce`.
 * Prefer `map` over `collect`.


### PR DESCRIPTION
- Having more than one exit path in a method is confusing
- Explicit return at the end of a method is unnecessarily noisy
