### PR TITLE
Update Style/README.md

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -196,7 +196,7 @@ Objective-C
 * Prefer `@class` to `#import` when referring to external classes in a public
   `@interface`.
 * Prefer `@property` to declaring instance variables.
-* Prefix class names with a 2-letter project acronym.
+* Prefix class names with a 3-letter project acronym.
 * Prefix string constants being used as keys with 'k'.
 * Remove `#import` statements for `Foundation` and `UIKit` in new project
   templates.


### PR DESCRIPTION
Updated Objective-C Style Advice about class prefixes. Apple says that class names should start with a 3-letter prefix acronym.

See relevant discussion here:
http://developer.apple.com/library/ios/#documentation/cocoa/conceptual/ProgrammingWithObjectiveC/Conventions/Conventions.html
