### PR TITLE
Change links' paths to relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ High level guidelines:
 * Don't rewrite existing code to follow this guide.
 * Don't violate a guideline without a good reason.
 
-* [Protocol](/thoughtbot/guides/blob/master/protocol)
-* [Code Review](/thoughtbot/guides/blob/master/code-review)
-* [Best Practices](/thoughtbot/guides/blob/master/best-practices)
-* [Style](/thoughtbot/guides/blob/master/style)
+* [Protocol](protocol)
+* [Code Review](code-review)
+* [Best Practices](best-practices)
+* [Style](style)
 
 A note on the language:
 
@@ -24,7 +24,7 @@ A note on the language:
 Credits
 -------
 
-Thank you, [contributors](/thoughtbot/guides/graphs/contributors)!
+Thank you, [contributors](https://github.com/thoughtbot/guides/graphs/contributors)!
 
 ![thoughtbot](http://thoughtbot.com/images/tm/logo.png)
 

--- a/code-review/README.md
+++ b/code-review/README.md
@@ -61,10 +61,10 @@ Understand why the code is necessary (bug, user experience, refactoring). Then:
 Style comments
 --------------
 
-Reviewers should comment on missed [style](/thoughtbot/guides/blob/master/style)
+Reviewers should comment on missed [style](../style)
 guidelines. Example comment:
 
-    [Style](/thoughtbot/guides/blob/master/style):
+    [Style](../style):
 
     > Order resourceful routes alphabetically by name.
 

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -8,8 +8,8 @@ Set up laptop
 
 Install the latest version of Xcode from the App Store.
 
-Set up your laptop with [this script](/thoughtbot/laptop)
-and [these dotfiles](/thoughtbot/dotfiles).
+Set up your laptop with [this script](https://github.com/thoughtbot/laptop)
+and [these dotfiles](https://github.com/thoughtbot/dotfiles).
 
 Create Rails app
 ----------------
@@ -54,7 +54,7 @@ Set up the app's dependencies.
     cd project
     ./bin/setup
 
-Use [Heroku config](/ddollar/heroku-config) to get `ENV`
+Use [Heroku config](https://github.com/ddollar/heroku-config) to get `ENV`
 variables.
 
     heroku config:pull -r staging
@@ -112,7 +112,7 @@ Review code
 -----------
 
 A team member other than the author reviews the pull request. They follow
-[Code Review](/thoughtbot/guides/blob/master/code-review) guidelines to avoid
+[Code Review](../code-review) guidelines to avoid
 miscommunication.
 
 They make comments and ask questions directly on lines of code in the Github

--- a/style/README.md
+++ b/style/README.md
@@ -76,7 +76,7 @@ CoffeeScript
 Ruby
 ----
 
-[Sample](/thoughtbot/guides/blob/master/style/samples/ruby.rb)
+[Sample](samples/ruby.rb)
 
 * Avoid conditional modifiers (lines that end with conditionals).
 * Avoid ternary operators (`boolean ? true : false`). Use multi-line `if`
@@ -102,7 +102,7 @@ Ruby
 ERb
 ---
 
-[Sample](/thoughtbot/guides/blob/master/style/samples/erb.rb)
+[Sample](samples/erb.rb)
 
 * When wrapping long lines, keep the method name on the same line as the ERb.
   interpolation operator and keep each method argument on its own line.
@@ -149,7 +149,7 @@ Email
 Testing
 -------
 
-[Sample](/thoughtbot/guides/blob/master/style/samples/testing.rb)
+[Sample](samples/testing.rb)
 
 * Avoid `its`, `let`, `let!`, `specify`, `before`, and `subject`.
 * Avoid using instance variables in tests.
@@ -184,7 +184,7 @@ Testing
 Objective-C
 -----------
 
-[Sample](/thoughtbot/guides/blob/master/style/samples/ObjectiveC.m)
+[Sample](samples/ObjectiveC.m)
 
 * `#import` linked frameworks in the prefix header (`ProjectName-Prefix.pch`).
 * Keep `.xib` files grouped with their associated view class.


### PR DESCRIPTION
Since github introduced news about [relative links in markup files](https://github.com/blog/1395-relative-links-in-markup-files) regular links with absolute path such as `/thoughtbot/guides/blob/master/...` will no longer works.
