### PR TITLE
Clean up Bundler guidelines

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -74,7 +74,6 @@ Bundler
 * Use an [exact
   version](http://robots.thoughtbot.com/post/35717411108/a-healthy-bundle#exact-version)
   in the `Gemfile` for fragile gems, such as Rails.
-* Use `--binstubs=bin/stubs` to avoid typing `bundle exec`.
 
 Postgres
 --------


### PR DESCRIPTION
- Remove old Bundler recommendation in Rails section, which has been
  superceded by the Bundler section.
- Alphabetize Bundler guidelines.
- Wrap at 80 characters where possible.
- Add binstubs guideline.
