### PR TITLE
Add .ruby-version guideline

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -59,6 +59,8 @@ Rails
   of models.
 * If there are default values, set them in migrations.
 * Keep `db/schema.rb` or `db/development_structure.sql` under version control.
+* Specify the Ruby version and patch level to be used on the project in the
+  [`.ruby-version`](https://gist.github.com/fnichol/1912050) file.
 * Use SQL, not `ActiveRecord` models, in migrations.
 * Use `_path`, not `_url`, for named routes everywhere except mailer views.
 * Validate the associated `belongs_to` object (`user`), not the database


### PR DESCRIPTION
The `.ruby-version` file is a common standard used by Ruby switchers to
choose which version of Ruby to be used by the project. Similar to the
`Gemfile.lock` file, which locks gem dependencies, this file helps maintain
development-production parity and avoid bugs such as:

https://twitter.com/sstephenson/status/286599900932739072

While the patch level theoretically should not make a difference, the reality
is that Ruby has a history of changing things with patch releases. For
example, Enumerator (and related methods) were introduced in a patch level of
1.8.7.
