### PR TITLE
Use `_url`, not `_path` for all named routes

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -60,8 +60,9 @@ Rails
 * If there are default values, set them in migrations.
 * Keep `db/schema.rb` or `db/development_structure.sql` under version control.
 * Use SQL, not `ActiveRecord` models, in migrations.
-* Use `_path`, not `_url`, for named routes everywhere except mailer views and
+* Use `_url` suffixes for named routes in mailer views and
   [redirects](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30).
+  Use `_path` suffixes for named routes everywhere else.
 * Validate the associated `belongs_to` object (`user`), not the database
   column (`user_id`).
 


### PR DESCRIPTION
Reasoning:
- `_url` is one character shorter, which helps with the 80-character
  guideline.
- Using a `_url` suffix in redirects better matches [RFC 2616 spec,
  section
  14.14.30](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30),
  which states the Location response-header field should use an absolute
  URI for 3xx responses. Rails converts `_path` suffixes to `_url`
  automatically for redirects but it is nice to be more intentional.
- Using `_url` everywhere makes it less likely we'll forget to use
  `_url` in mailer views.
