### PR TITLE
Update rebasing/fetching in protocol guide

### DIFF
--- a/protocol/README.md
+++ b/protocol/README.md
@@ -168,7 +168,7 @@ Delete your remote feature branch.
 
 Delete your local feature branch.
 
-    git branch -d <branch-name>
+    git branch --delete <branch-name>
 
 Deploy
 ------


### PR DESCRIPTION
Functional changes:
- Don't forget to fetch before rebasing.
- Change Thin recommendation to Unicorn.
- Remove `--rebase` due to discussion
  [here](https://github.com/thoughtbot/dotfiles/pull/111).

Improvements for better readability/documentation:
- Use full options flags for clarity.
- Use `[branch-name]` consistently (brackets and `-name` suffix).
- Replace `<>` style code comments with sentence instructions.
