### PR TITLE
Add Sandi Metz’ rules for developers

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -54,22 +54,6 @@ Organization
 * Order methods so that methods are as close as possible to other methods they
   call.
 
-Sandi Metz’ rules for developers
---------------------------------
-
-1. Classes can be no longer than a hundred lines of code.
-2. Methods can be no longer than five lines of code.
-3. Method calls can have no more than four parameters. Hash options _are_
-   parameters.
-4. Controllers can only instantiate one object to do whatever it is that
-   needs to be done.
-
-   This has a couple of corollaries for views:
-
-   1. Views can only know about one instance variable.
-   2. Views should only send messages to that object i.e., no Demeter
-      violations. (`@object.collaborator.value` is not allowed)
-
 
 Sass
 ----
@@ -118,6 +102,7 @@ Ruby
 * Use `def` with parentheses when there are arguments.
 * Use `each`, not `for`, for iteration.
 * Use heredocs for multi-line strings.
+* Follow Sandi Metz' rules for developers.
 
 ERb
 ---


### PR DESCRIPTION
We’ve determined that using Metz’ rules has been a success, so I’ve pulled these
out of the technical guidelines document for our project which was using them.

[Ruby Rogues Book
Club](http://rubyrogues.com/087-rr-book-clubpractical-object-oriented-design-in-ruby-with-sandi-metz/)

@halogenandtoast @croaky @derekprior @mjankowski @mike-burns 
