### PR TITLE
Prioritize @extends an @includes within Sass rule sets

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -61,7 +61,7 @@ Sass
 * Use dashes when naming mixins, extends, classes or IDs: `span-columns` not `span_columns` or `spanColumns`.
 * Use descriptive names and write them in full-words: `$visual-grid-color` not `$color` or `$vslgrd-clr`.
 * Use space between property and value: `width: 20px` not `width:20px`.
-* Order properties within rule sets alphabetically.
+* Order properties within rule sets with @extends and @includes first, then all others alphabetically.
 * Leave a blank line between rule sets.
 
 CoffeeScript


### PR DESCRIPTION
When ordering selectors @includes and @extends to me are much more important and I don't want to be 'hunting for them' within a selector's ruleset.

This feels much better to me,

``` scss
ul {
  @include span-columns(5);
  border-bottom: 1px solid rgba(0,0,0,.1);
  border-top: 1px solid rgba(0,0,0,.1);
  list-style-type: none;
}
```

as opposed to traditionally,

``` scss
ul {
  border-bottom: 1px solid rgba(0,0,0,.1);
  border-top: 1px solid rgba(0,0,0,.1);
  list-style-type: none;
  @include span-columns(5);
}
```
