### PR TITLE
add Mailtrap service to Email section

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -121,7 +121,7 @@ Background Jobs
 Email
 -----
 
-* Use [SendGrid](http://goo.gl/Kxu9W) or [Amazon SES](http://goo.gl/A5jAA) to
+* Use [SendGrid](http://goo.gl/Kxu9W) or [Amazon SES](http://goo.gl/A5jAA) or [Mailtrap](goo.gl/9ltr0) to
   deliver email in staging and production environments.
 * Use a tool like [mail_view](http://goo.gl/HhX8y) to look at each created or
   updated mailer view before merging.


### PR DESCRIPTION
Mailtrap.io - Fake SMTP server for a development teams to test, view and share transactional and other emails sent from dev and staging environments, without spamming real customers.
