### PR TITLE
Add rule avoid `any_instance` in RSpec.

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -75,7 +75,7 @@ Rails
 Testing
 -------
 
-* Avoid `any_instance` in rspec-mocks and mocha.
+* Avoid `any_instance` in rspec-mocks and mocha. Prefer [dependency injection].
 * Avoid `its`, `let`, `let!`, `specify`, `before`, and `subject` in RSpec.
 * Avoid using instance variables in tests.
 * Don't test private methods.
@@ -85,6 +85,7 @@ Testing
 * Use [assertions about state] for incoming messages.
 * Use stubs and spies to assert you sent outgoing messages.
 
+[dependency injection]: http://en.wikipedia.org/wiki/Dependency_injection
 [assertions about state]: https://speakerdeck.com/skmetz/magic-tricks-of-testing-railsconf?slide=51
 
 Bundler


### PR DESCRIPTION
- `any_instance` promotes depending on concretions.
- `any_instance` hides complexity.
- Pure stubs promotes isolation and dependency injection.
- Using dependency injection promotes inversion of control.
