### PR TITLE
Reformat links in lists to use reference style

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -9,8 +9,11 @@ General
 * Don't duplicate the functionality of a built-in library.
 * Don't swallow exceptions or "fail silently."
 * Don't write code that guesses at future functionality.
-* [Exceptions should be exceptional](http://rdd.me/yichhgvu).
-* [Keep the code simple](http://rdd.me/ko2aqda2).
+* [Exceptions should be exceptional].
+* [Keep the code simple].
+
+[Exceptions should be exceptional]: http://rdd.me/yichhgvu
+[Keep the code simple]: http://rdd.me/ko2aqda2
 
 Object-Oriented Design
 ----------------------
@@ -23,7 +26,9 @@ Object-Oriented Design
 * Prefer small methods. Between one and five lines is best.
 * Prefer small objects with a single, well-defined responsibility. When an
   object exceeds 100 lines, it may be doing too many things.
-* [Tell, don't ask](http://goo.gl/Ztawt).
+* [Tell, don't ask].
+
+[Tell, don't ask]: http://goo.gl/Ztawt
 
 Ruby
 ----
@@ -40,13 +45,15 @@ Ruby Gems
 
 * Declare dependencies in the `<PROJECT_NAME>.gemspec` file.
 * Reference the `gemspec` in the `Gemfile`.
-* Use [Appraisal](http://github.com/thoughtbot/appraisal) to test the gem
-  against multiple versions of gem dependencies (such as Rails in a Rails
-  engine).
-* Use [Bundler](http://gembundler.com/) to manage the gem's dependencies.
-* Use [Travis CI](http://travisci.org) for Continuous Integration, indicators
-  showing whether GitHub pull requests can be merged, and to test against
-  multiple Ruby versions.
+* Use [Appraisal] to test the gem against multiple versions of gem dependencies
+  (such as Rails in a Rails engine).
+* Use [Bundler] to manage the gem's dependencies.
+* Use [Travis CI] for Continuous Integration, indicators showing whether GitHub
+  pull requests can be merged, and to test against multiple Ruby versions.
+
+[Appraisal]: http://github.com/thoughtbot/appraisal
+[Bundler]: http://gembundler.com/
+[Travis CI]: http://travisci.org
 
 Rails
 -----
@@ -58,19 +65,21 @@ Rails
 * Don't change a migration after it has been merged into master if the desired
   change can be solved with another migration.
 * Don't reference a model class directly from a view.
-* Don't use SQL or SQL fragments (`where('inviter_id IS NOT NULL')`) outside
-  of models.
+* Don't use SQL or SQL fragments (`where('inviter_id IS NOT NULL')`) outside of
+  models.
 * If there are default values, set them in migrations.
 * Keep `db/schema.rb` or `db/development_structure.sql` under version control.
 * Use only one instance variable in each view.
 * Use SQL, not `ActiveRecord` models, in migrations.
-* Use the [`.ruby-version`](https://gist.github.com/fnichol/1912050) file
-  convention to specify the Ruby version and patch level for a project.
-* Use `_url` suffixes for named routes in mailer views and
-  [redirects](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30).
-  Use `_path` suffixes for named routes everywhere else.
-* Validate the associated `belongs_to` object (`user`), not the database
-  column (`user_id`).
+* Use the [`.ruby-version`] file convention to specify the Ruby version and
+  patch level for a project.
+* Use `_url` suffixes for named routes in mailer views and [redirects].  Use
+  `_path` suffixes for named routes everywhere else.
+* Validate the associated `belongs_to` object (`user`), not the database column
+  (`user_id`).
+
+[`.ruby-version`]: https://gist.github.com/fnichol/1912050
+[redirects]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30
 
 Testing
 -------
@@ -78,39 +87,42 @@ Testing
 * Avoid `its`, `let`, `let!`, `specify`, `before`, and `subject` in RSpec.
 * Avoid using instance variables in tests.
 * Don't test private methods.
-* Use [stubs and spies](http://goo.gl/EciDJ) (not mocks) in isolated tests.
+* Use [stubs and spies] (not mocks) in isolated tests.
 * Use a single level of abstraction within scenarios.
 * Use an `it` example or test method for each execution path through the method.
 * Use [assertions about state] for incoming messages.
 * Use stubs and spies to assert you sent outgoing messages.
 
 [assertions about state]: https://speakerdeck.com/skmetz/magic-tricks-of-testing-railsconf?slide=51
+[stubs and spies]: http://goo.gl/EciDJ
 
 Bundler
 -------
 
-* Specify the [Ruby version](http://gembundler.com/v1.3/gemfile_ruby.html) to be
-  used on the project in the `Gemfile`.
-* Use a [pessimistic
-  version](http://robots.thoughtbot.com/post/35717411108/a-healthy-bundle#pessimistic-version)
-  in the `Gemfile` for gems that follow semantic versioning, such as `rspec`,
-  `factory_girl`, and `capybara`.
-* Use a
-  [versionless](http://robots.thoughtbot.com/post/35717411108/a-healthy-bundle#versionless)
-  `Gemfile` declarations for gems that are safe to update often, such as pg, thin,
-  and debugger.
-* Use an [exact
-  version](http://robots.thoughtbot.com/post/35717411108/a-healthy-bundle#exact-version)
-  in the `Gemfile` for fragile gems, such as Rails.
+* Specify the [Ruby version] to be used on the project in the `Gemfile`.
+* Use a [pessimistic version] in the `Gemfile` for gems that follow semantic
+  versioning, such as `rspec`, `factory_girl`, and `capybara`.
+* Use a [versionless] `Gemfile` declarations for gems that are safe to update
+  often, such as pg, thin, and debugger.
+* Use an [exact version] in the `Gemfile` for fragile gems, such as Rails.
+
+[Ruby version]: http://gembundler.com/v1.3/gemfile_ruby.html
+[exact version]: http://robots.thoughtbot.com/post/35717411108/a-healthy-bundle#exact-version
+[pessimistic version]: http://robots.thoughtbot.com/post/35717411108/a-healthy-bundle#pessimistic-version
+[versionless]: http://robots.thoughtbot.com/post/35717411108/a-healthy-bundle#versionless
 
 Postgres
 --------
 
-* Avoid multicolumn indexes in Postgres. It [combines multiple
-  indexes](http://goo.gl/pY3Po) efficiently. Optimize later with a [compound
-  index if needed](http://www.postgresql.org/docs/9.2/static/indexes-bitmap-scans.html).
-* Consider a [partial index](http://goo.gl/YC8Jt) for queries on booleans.
-* Constrain most columns as [`NOT NULL`](http://goo.gl/0GeBr).
+* Avoid multicolumn indexes in Postgres. It [combines multiple indexes]
+  efficiently. Optimize later with a [compound index] if needed.
+* Consider a [partial index] for queries on booleans.
+* Constrain most columns as [`NOT NULL`].
+
+[`NOT NULL`]: http://goo.gl/0GeBr
+[combines multiple indexes]: http://goo.gl/pY3Po
+[compound index]: http://www.postgresql.org/docs/9.2/static/indexes-bitmap-scans.html
+[partial index]: http://goo.gl/YC8Jt
 
 Background Jobs
 ---------------
@@ -121,20 +133,28 @@ Background Jobs
 Email
 -----
 
-* Use [SendGrid](http://goo.gl/Kxu9W) or [Amazon SES](http://goo.gl/A5jAA) to
-  deliver email in staging and production environments.
-* Use a tool like [mail_view](http://goo.gl/HhX8y) to look at each created or
-  updated mailer view before merging.
+* Use [SendGrid] or [Amazon SES] to deliver email in staging and production
+  environments.
+* Use a tool like [mail_view] to look at each created or updated mailer view
+  before merging.
+
+[Amazon SES]: http://goo.gl/A5jAA
+[SendGrid]: http://goo.gl/Kxu9W
+[mail_view]: http://goo.gl/HhX8y
 
 Testing
 -------
 
 * Disable real HTTP requests to external services with
   `WebMock.disable_net_connect!`.
-* Test background jobs with a [`Delayed::Job` matcher](http://goo.gl/bzBlN).
-* Use a [Fake](http://goo.gl/YR7Hh) to stub requests to external services.
+* Test background jobs with a [`Delayed::Job` matcher].
+* Use a [Fake] to stub requests to external services.
 * Use integration tests to execute the entire app.
-* Use non-[SUT](http://goo.gl/r5Ti2) methods in expectations when possible.
+* Use non-[SUT] methods in expectations when possible.
+
+[Fake]: http://goo.gl/YR7Hh
+[SUT]: http://goo.gl/r5Ti2
+[`Delayed::Job` matcher]: http://goo.gl/bzBlN
 
 JavaScript
 ----------

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -77,7 +77,9 @@ Maintain a Rails app
 * Delete local and remote feature branches after merging.
 * Perform work in a feature branch.
 * Rebase frequently to incorporate upstream changes.
-* Use a [pull request](http://goo.gl/Kmdee) for code reviews.
+* Use a [pull request] for code reviews.
+
+[pull request]: http://goo.gl/Kmdee
 
 Write a feature
 ---------------
@@ -209,10 +211,11 @@ Close pull request and comment `Merged.`
 Set Up Production Environment
 -----------------------------
 
-* Make sure that your
-  [`Procfile`](https://devcenter.heroku.com/articles/procfile)
-  is set up to run Unicorn.
+* Make sure that your [`Procfile`] is set up to run Unicorn.
 * Make sure the PG Backups add-on is enabled.
-* Create a read-only [Heroku Follower](http://goo.gl/xWDMx) for your
-  production database. If a Heroku database outage occurs, Heroku can use the
-  follower to get your app back up and running faster.
+* Create a read-only [Heroku Follower] for your production database. If a Heroku
+  database outage occurs, Heroku can use the follower to get your app back up
+  and running faster.
+
+[Heroku Follower]: http://goo.gl/xWDMx
+[`Procfile`]: https://devcenter.heroku.com/articles/procfile

--- a/style/README.md
+++ b/style/README.md
@@ -7,7 +7,9 @@ Git
 ---
 
 * Prefix feature branch names with your initials.
-* Write a [good commit message](http://goo.gl/w11us).
+* Write a [good commit message].
+
+[good commit message]: http://goo.gl/w11us
 
 Formatting
 ----------
@@ -29,9 +31,11 @@ Formatting
 * Use newlines around multi-line blocks.
 * Use spaces around operators, after commas, after colons and semicolons, around
   `{` and before `}`.
-* Use [Unix-style line endings](http://goo.gl/04ehM) (`\n`).
-* Use [uppercase for SQL key words and lowercase for SQL
-  identifiers](http://goo.gl/0WAIX).
+* Use [Unix-style line endings] (`\n`).
+* Use [uppercase for SQL key words and lowercase for SQL identifiers].
+
+[uppercase for SQL key words and lowercase for SQL identifiers]: http://goo.gl/0WAIX
+[Unix-style line endings]: http://goo.gl/04ehM
 
 Naming
 ------
@@ -126,10 +130,11 @@ Rails
 * Order ActiveRecord validations alphabetically by attribute name.
 * Order controller contents: filters, public methods, private methods.
 * Order model contents: constants, macros, public methods, private methods.
-* Put application-wide partials in the
-  [`app/views/application`](http://goo.gl/5Z8Vv) directory.
+* Put application-wide partials in the [`app/views/application`] directory.
 * Use `def self.method`, not the `scope :method` DSL.
 * Use the default `render 'partial'` syntax over `render partial: 'partial'`.
+
+[`app/views/application`]: http://goo.gl/5Z8Vv
 
 Rails Routes
 ------------
@@ -150,7 +155,9 @@ Email
 
 * Use one `ActionMailer` for the app. Name it `Mailer`.
 * Use the user's name in the `From` header and email in the `Reply-To` when
-  [delivering email on behalf of the app's users](http://goo.gl/5w1ck).
+  [delivering email on behalf of the app's users].
+
+[delivering email on behalf of the app's users]: http://goo.gl/5w1ck
 
 Testing
 -------
@@ -179,11 +186,12 @@ Testing
 * Use names like `ROLE_ACTION_spec.rb`, such as
   `user_changes_password_spec.rb`, for feature spec file names.
 * Use only one `feature` block per feature spec file.
-* Use RSpec's [`expect`
-  syntax](http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax).
+* Use RSpec's [`expect` syntax].
 * Use scenario titles that describe the success and failure paths.
 * Use spec/features to store feature specs.
 * Use spec/support/features for support code related to feature specs.
+
+[`expect` syntax]: http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
 
 Objective-C
 -----------
@@ -217,4 +225,6 @@ Objective-C
 Python
 ------
 
-* Follow [PEP 8](http://www.python.org/dev/peps/pep-0008/).
+* Follow [PEP 8].
+
+[PEP 8]: http://www.python.org/dev/peps/pep-0008/


### PR DESCRIPTION
- Prevents wrapping long list items, improving readability
- Removes the need for short URLs
