### PR TITLE
Clarify meaning of feature spec naming

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -177,7 +177,7 @@ Testing
 * Separate setup, exercise, verification, and teardown phases with newlines.
 * Use one factories.rb file per project.
 * Use names like `ROLE_ACTION_spec.rb`, such as
-  `user_changes_password_spec.rb`, for feature spec file names.
+  `user_changes_password_spec.rb`, for feature spec file names, where ROLE_ACTION is in caps because...
 * Use only one `feature` block per feature spec file.
 * Use RSpec's [`expect`
   syntax](http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax).


### PR DESCRIPTION
What does 

```
Use names like `ROLE_ACTION_spec.rb`, such as `user_changes_password_spec.rb`, for feature spec file names
```

mean?  I'm happy to clarify, but I can't make heads nor tails of the sentence.
