### PR TITLE
Add guideline: avoid multiple assignments per line

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -87,8 +87,8 @@ Ruby
 [Sample](samples/ruby.rb)
 
 * Avoid conditional modifiers (lines that end with conditionals).
+* Avoid multiple assignments per line (`one, two = 1, 2`).
 * Avoid organizational comments (`# Validations`).
-* Avoid multiple assignments per line (`one two, = 1, 2`).
 * Avoid ternary operators (`boolean ? true : false`). Use multi-line `if`
   instead to emphasize code branches.
 * Avoid explicit return statements.


### PR DESCRIPTION
- Reading requires scanning back and forth across the line
- Adding more assignments causes modifications instead of additions
- Hides complexity
- Easy to miss when scanning a method
