### PR TITLE
Don't use instance variables in partials

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -65,6 +65,8 @@ Rails
 * Don't change a migration after it has been merged into master if the desired
   change can be solved with another migration.
 * Don't reference a model class directly from a view.
+* Don't use instance variables in partials. Pass local variables to partials
+  from view templates.
 * Don't use SQL or SQL fragments (`where('inviter_id IS NOT NULL')`) outside of
   models.
 * If there are default values, set them in migrations.


### PR DESCRIPTION
- It is hard to reason about the source of instance variables in
  partials because the source is too far away.
- Like globals, they're not given to you by your caller, and
  maybe not even your caller's caller.
- That makes it hard to figure out what you're changing when you change the
  instance variable.
- It couples the partial to the place it's first used.
- If you use locals, then you can follow the chain all the way back.

Thanks to @gabebw, @calebthompson, and @pbrisbin.
