### PR TITLE
Add style guidelines on squashing and merging

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -6,9 +6,12 @@ A guide for programming in style.
 Git
 ---
 
+* Avoid merge commits by using a [rebase workflow].
 * Prefix feature branch names with your initials.
+* Squash multiple trivial commits into a single commit.
 * Write a [good commit message].
 
+[rebase workflow]: https://github.com/thoughtbot/guides/tree/master/protocol#merge
 [good commit message]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 
 Formatting


### PR DESCRIPTION
- Merge commits add noise the Git log.
- A tree-based history is harder to follow than a linear log.
- Encourages small, cohesive commits.

Some of this is already covered in Protocl and Best Practices, but I
thought it would be good to have something here related to the style
of Git log we want to have.

In particular, I want to avoid "Merged pull request #something" and
"Merged master into somebody/master" commits.
