### PR TITLE
Update guidelines on Rails' Mailers

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -152,6 +152,8 @@ Email
   environments.
 * Use a tool like [mail_view] to look at each created or updated mailer view
   before merging.
+* Start with one `ActionMailer` for the app; name it `Mailer`.
+* Consider multiple mailers if emails can be grouped conceptually.
 
 [Amazon SES]: http://goo.gl/A5jAA
 [SendGrid]: http://goo.gl/Kxu9W

--- a/style/README.md
+++ b/style/README.md
@@ -189,7 +189,6 @@ Background Jobs
 Email
 -----
 
-* Use one `ActionMailer` for the app. Name it `Mailer`.
 * Use the user's name in the `From` header and email in the `Reply-To` when
   [delivering email on behalf of the app's users].
 


### PR DESCRIPTION
- Move mailer suggestion to Best Practices section
- Update suggestion to mention breaking mailers apart when it makes
  sense to do so
