### PR TITLE
Use ERB

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -79,6 +79,7 @@ Rails
   `_path` suffixes for named routes everywhere else.
 * Validate the associated `belongs_to` object (`user`), not the database column
   (`user_id`).
+* Use ERB for HTML templates.
 
 [`.ruby-version`]: https://gist.github.com/fnichol/1912050
 [redirects]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30


### PR DESCRIPTION
Many templating fads have come and gone---our favorite contender being
effigy, of course---but throughout it all the Rails default, ERB, has
remained like a mountain, strongly drawing a distinction between Ruby
and template output, standing by while you write whatever HTML the
browser needs, turning a blind eye to any validation errors and unclosed
tags, never judging you for working around IE bugs with comments and
whitespace.

So let's use ERB by default. New designers and all clients can
understand it, our most backend of devs can work with it, and it's the
Rails default.
