### PR TITLE
changed case for classnames

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -112,7 +112,7 @@ CoffeeScript
 
 * Initialize arrays using `[]`.
 * Initialize empty objects and hashes using `{}`.
-* Use `CamelCase` for classes, `lowerCamelCase` for variables and functions,
+* Use `PascalCase` for classes, `lowerCamelCase` for variables and functions,
   `SCREAMING_SNAKE_CASE` for constants, `_single_leading_underscore` for
   private variables and functions.
 * Prefer `is` to `== ` or `===`


### PR DESCRIPTION
Camel Case usually refers to both camelCase as well as CamelCase. PascalCase is a less ambiguous term.
