### PR TITLE
Use hyphen-separated filenames for Coffeescript

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -112,6 +112,7 @@ CoffeeScript
 
 * Initialize arrays using `[]`.
 * Initialize empty objects and hashes using `{}`.
+* Use hyphen-separated filenames, such as `coffee-script.coffee`.
 * Use `PascalCase` for classes, `lowerCamelCase` for variables and functions,
   `SCREAMING_SNAKE_CASE` for constants, `_single_leading_underscore` for
   private variables and functions.


### PR DESCRIPTION
- This is what Coffeescript itself uses.
- Resolves #56.
