### PR TITLE
Add guideline to order i18n keys alphabetically

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -176,6 +176,7 @@ Rails
 * Order ActiveRecord associations alphabetically by attribute name.
 * Order ActiveRecord validations alphabetically by attribute name.
 * Order controller contents: filters, public methods, private methods.
+* Order i18n translations alphabetically by key name.
 * Order model contents: constants, macros, public methods, private methods.
 * Put application-wide partials in the [`app/views/application`] directory.
 * Use `def self.method`, not the `scope :method` DSL.


### PR DESCRIPTION
Ordering Rails i18n keys alphabetically makes the translations file easier to
navigate as well as making merge conflicts easier to deal with.
