### PR TITLE
Exception to syntax style when using shoulda

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -217,9 +217,11 @@ Testing
 * Prefer `eq` to `==` in RSpec.
 * Separate setup, exercise, verification, and teardown phases with newlines.
 * Use RSpec's [`expect` syntax].
+* Use `should` shorthand for [one-liners with an implicit subject].
 * Use `not_to` instead of `to_not` in RSpec expectations.
 
 [`expect` syntax]: http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
+[one-liners with an implicit subject]: https://github.com/rspec/rspec-expectations/blob/master/Should.md#one-liners
 
 #### Acceptance Tests
 


### PR DESCRIPTION
Although the rest of our test suite uses the `expect` syntax without an
implicit `subject`, expectations made with `shoulda-matchers` are
cleaner and more concise when using `should` and an implicit `subject`.
