### PR TITLE
Prefer rescue without begin/end

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -149,6 +149,7 @@ Ruby
 * Use `def self.method`, not `def Class.method` or `class << self`.
 * Use `def` with parentheses when there are arguments.
 * Use `each`, not `for`, for iteration.
+* Use `rescue` without `begin`/`end` when possible.
 * Use heredocs for multi-line strings.
 
 ERb

--- a/style/samples/ruby.rb
+++ b/style/samples/ruby.rb
@@ -72,6 +72,12 @@ class SomeClass
     user.ensure_authenticated!
   end
 
+  def method_which_raises_an_exception
+    behavior_that_might_raise
+  rescue ExceptionClass => exception
+    handle_exception exception
+  end
+
   def self.class_method
     method_body
   end


### PR DESCRIPTION
- Less boilerplate
- Makes it more obvious when a new method can be extracted
