### PR TITLE
Remain undecided on begin/rescue/end

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -149,7 +149,6 @@ Ruby
 * Use `def self.method`, not `def Class.method` or `class << self`.
 * Use `def` with parentheses when there are arguments.
 * Use `each`, not `for`, for iteration.
-* Use `rescue` without `begin`/`end` when possible.
 * Use heredocs for multi-line strings.
 
 ERb

--- a/style/samples/ruby.rb
+++ b/style/samples/ruby.rb
@@ -72,12 +72,6 @@ class SomeClass
     user.ensure_authenticated!
   end
 
-  def method_which_raises_an_exception
-    behavior_that_might_raise
-  rescue ExceptionClass => exception
-    handle_exception exception
-  end
-
   def self.class_method
     method_body
   end


### PR DESCRIPTION
In #135 this remained a controversial decision, with some arguing that
the code becomes difficult to read without `begin`, others arguing that
it makes it too hard to see what the raising method call is. Since we
are still undecided on this, we can revert this decision.

This reverts commit eb024567d5cb7eed7cfeeac122f133b239d4f3ed.
