### PR TITLE
Avoid trailing conditionals in CoffeeScript

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -110,6 +110,7 @@ Sass
 CoffeeScript
 ------------
 
+* Avoid conditional modifiers (lines that end with conditionals).
 * Initialize arrays using `[]`.
 * Initialize empty objects and hashes using `{}`.
 * Use hyphen-separated filenames, such as `coffee-script.coffee`.


### PR DESCRIPTION
The same reasons for avoiding trailing conditionals in Ruby apply to
CoffeeScript. Therefore, we should avoid them in CoffeeScript too.
