### PR TITLE
Remove the triple equals operator in the coffee styles.

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -116,7 +116,7 @@ CoffeeScript
 * Use `PascalCase` for classes, `lowerCamelCase` for variables and functions,
   `SCREAMING_SNAKE_CASE` for constants, `_single_leading_underscore` for
   private variables and functions.
-* Prefer `is` to `== ` or `===`
+* Prefer `is` to `== `
 * Prefer `or` and `and` to `||` and `&&`
 
 Ruby


### PR DESCRIPTION
The triple equals operator does not exist in coffeescript and will not compile with it. So this bit is not necessary.
