### PR TITLE
Update style guide on unit test to match our usage

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -251,10 +251,16 @@ Testing
 
 [Sample](samples/testing.rb)
 
-* Don't prefix `it` block descriptions with `should`. Use
-  [Imperative mood](http://en.wikipedia.org/wiki/Imperative_mood) instead.
-* Name outer `describe` blocks after the method under test. Use `.method`
-  for class methods and `#method` for instance methods.
+* Don't prefix `it` block descriptions with `should`. Use [Imperative mood]
+  instead.
+* Put one-liner specs at the beginning of the outer `describe` blocks.
+* Use `.method` to describe class methods and `#method` to describe instance
+  methods.
+* Use `context` to describe testing preconditions.
+* Use `describe '#method_name'` to group tests by method-under-test
+* Use a single, top-level `describe ClassName` block.
+
+[Imperative mood]: http://en.wikipedia.org/wiki/Imperative_mood
 
 Objective-C
 -----------

--- a/style/samples/testing.rb
+++ b/style/samples/testing.rb
@@ -1,15 +1,30 @@
-describe SomeClass, '#some_method' do
-  it 'does something' do
-    expect(something).to eq 'something'
-  end
-end
+describe SomeClass do
+  it { should have_one(:association) }
+  it { should validate_presence_of(:some_attribute) }
 
-describe SomeClass, '#other_method' do
-  it 'does something in one case' do
-  end
-
-  it 'does something else in other cases' do
+  describe '.some_class_method' do
+    it 'does something' do
+      # ...
+    end
   end
 
-  # methods go here
+  describe '#some_instance_method' do
+    it 'does something' do
+      expect(something).to eq 'something'
+    end
+  end
+
+  describe '#another_instance_method' do
+    context 'when in one case' do
+      it 'does something' do
+        # ...
+      end
+    end
+
+    context 'when in other case' do
+      it 'does something else' do
+        # ...
+      end
+    end
+  end
 end


### PR DESCRIPTION
Per discussions[[1](https://thoughtbot.campfirenow.com/room/522129/transcript/message/1184746412#message_1184535060)],[[2](https://thoughtbot.campfirenow.com/room/522129/transcript/message/1209240323#message_1209240323)], this better matches what we are actually doing on projects.
