### PR TITLE
Specify method chaining dot style rule

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -29,6 +29,9 @@ Formatting
   brace on its own line.
 * Indent continued lines two spaces.
 * Indent private methods equal to public methods.
+* If you break up a chain of method invocations, keep each method invocation on
+  its own line. Place the `.` at the end of each line, except the last.
+  [Example][dot guideline example].
 * Use 2 space indentation (no tabs).
 * Use an empty line between methods.
 * Use newlines around multi-line blocks.
@@ -37,6 +40,7 @@ Formatting
 * Use [Unix-style line endings] (`\n`).
 * Use [uppercase for SQL key words and lowercase for SQL identifiers].
 
+[dot guideline example]: https://github.com/thoughtbot/guides/blob/master/style/samples/ruby.rb#L11
 [uppercase for SQL key words and lowercase for SQL identifiers]: http://www.postgresql.org/docs/9.2/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 [Unix-style line endings]: http://unix.stackexchange.com/questions/23903/should-i-end-my-text-script-files-with-a-newline
 

--- a/style/samples/ruby.rb
+++ b/style/samples/ruby.rb
@@ -8,8 +8,9 @@ class SomeClass
   end
 
   def method_with_arguments(argument_one, argument_two)
-    this_is_a_really_long_line_that_should_be_broken_up_over_multiple_lines_and.
-      every_line_but_the_first_is_indented
+    a_really_long_line_that_is_broken_up_over_multiple_lines_and.
+      subsequent_lines_are_indented_and.
+      each_method_lives_on_its_own_line
   end
 
   def method_with_multiline_block


### PR DESCRIPTION
When splitting long lines place the dot on the same line as the method:

``` ruby
foo.bar
  .baz
```
