### PR TITLE
Update ruby.rb

### DIFF
--- a/style/samples/ruby.rb
+++ b/style/samples/ruby.rb
@@ -23,7 +23,7 @@ class SomeClass
   end
 
   def method_with_single_line_block
-    items.map(&:some_attribute)
+    items.map { |item| "#{item.prefix} #{item.description}" }
   end
 
   def method_that_returns_an_array


### PR DESCRIPTION
Use symbol-to-proc whenever possible.

Changed

``` ruby
items.map { |item| item.some_attribute }
```

to:

``` ruby
items.map(&:some_attribute)
```
