### PR TITLE
Use has_css? instead of has_selector? in RSpec

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -219,6 +219,7 @@ Testing
 * Use RSpec's [`expect` syntax].
 * Use `should` shorthand for [one-liners with an implicit subject].
 * Use `not_to` instead of `to_not` in RSpec expectations.
+* Prefer the `have_css` matcher to the `have_selector` matcher in Capybara assertions.
 
 [`expect` syntax]: http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
 [one-liners with an implicit subject]: https://github.com/rspec/rspec-expectations/blob/master/Should.md#one-liners


### PR DESCRIPTION
While has_selector? supports CSS selectors and XPath selectors, has_css? is
most often how we assert elements are present in the DOM; as an added benefit,
it's shorter to type.
