### PR TITLE
Use `or` for Ruby alternatives to `nil`

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -142,7 +142,8 @@ Ruby
 * Prefer single quotes for strings.
 * Use `_` for unused block parameters.
 * Use `%{}` for single-line strings needing interpolation and double-quotes.
-* Use `&&` and `||` for Boolean expressions.
+* Use `&&` and `||` instead of `and` and `or` for expressions which return
+  `true` or `false`.
 * Use `{...}` for single-line blocks. Use `do..end` for multi-line blocks.
 * Use `?` suffix for predicate methods.
 * Use `CamelCase` for classes and modules, `snake_case` for variables and
@@ -150,6 +151,8 @@ Ruby
 * Use `def self.method`, not `def Class.method` or `class << self`.
 * Use `def` with parentheses when there are arguments.
 * Use `each`, not `for`, for iteration.
+* Use `or` instead of `||` for expressions which return an alternative value for
+  `nil`.
 * Use heredocs for multi-line strings.
 
 ERb

--- a/style/samples/ruby.rb
+++ b/style/samples/ruby.rb
@@ -72,6 +72,10 @@ class SomeClass
     user.ensure_authenticated!
   end
 
+  def method_with_alterative
+    User.first or User.default
+  end
+
   def self.class_method
     method_body
   end


### PR DESCRIPTION
- Clarify boolean expression rule for `&&`, `||`
- Suggest `or` for expressions not involving `true` or `false`

https://github.com/thoughtbot/whetstone/pull/30/files#r10706657
