### PR TITLE
Prefer `==` to `is` in CoffeeScript

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -126,8 +126,8 @@ CoffeeScript
 * Use `PascalCase` for classes, `lowerCamelCase` for variables and functions,
   `SCREAMING_SNAKE_CASE` for constants, `_single_leading_underscore` for
   private variables and functions.
-* Prefer `is` to `== `
-* Prefer `or` and `and` to `||` and `&&`
+* Prefer `==` and `!=` to `is` and `isnt`
+* Prefer `||` and `&&` to `or` and `and`
 
 Ruby
 ----


### PR DESCRIPTION
Given that we prefer things like `&&` to `and` in ruby and other
languages, it'd be nice to be consistent about this in CoffeeScript as
well. I also find code that uses `is`, `isnt`, `and`, and `or` to be
signficantly less readable.
