### PR TITLE
change newline to emtpy line

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -34,7 +34,7 @@ Formatting
   [Example][dot guideline example].
 * Use 2 space indentation (no tabs).
 * Use an empty line between methods.
-* Use newlines around multi-line blocks.
+* Use empty lines around multi-line blocks.
 * Use spaces around operators, after commas, after colons and semicolons, around
   `{` and before `}`.
 * Use [Unix-style line endings] (`\n`).


### PR DESCRIPTION
This updates make the use of `empty line` more consistent.  In my mind, `newline` means a single carriage return whereas `empty line` means double carriage return so that you create an empty line between the previous code and the new code.

A newline after the first line:

```
first line
second line
```

An empty line after the first line:

```
first line

second line
```
