### PR TITLE
Add migration styles

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -189,6 +189,16 @@ Rails
 
 [`app/views/application`]: http://asciicasts.com/episodes/269-template-inheritance
 
+Rails Migrations
+----------------
+* Set an empty string as the default constraint for non-required string and text
+  fields. [Example][default example].
+* List timestamps first when creating a new table. [Example][timestamps
+  example].
+
+[timestamps example]: /style/samples/migration.rb
+[default example]: /style/samples/migration.rb#L6
+
 Rails Routes
 ------------
 
@@ -308,10 +318,9 @@ Shell
 
 * Break long lines on `|`, `&&`, or `||` and indent the continuations.
 * Don't add an extension to executable shell scripts.
-* Don't put a line break before `then` or `do`, use `if ...; then` and 
-  `while ...; do`.
+* Don't put a line break before `then` or `do`, use `if ...; then` and `while
+  ...; do`.
 * Use `for x; do`, not `for x in "$@"; do`.
-* Use `snake_case` for variable names and `ALLCAPS` for environment 
-  variables.
+* Use `snake_case` for variable names and `ALLCAPS` for environment variables.
 * Use single quotes for strings that don't contain escapes or variables.
 * Use two-space indentation.

--- a/style/samples/migration.rb
+++ b/style/samples/migration.rb
@@ -1,0 +1,11 @@
+class CreateClearanceUsers < ActiveRecord::Migration
+  def change
+    create_table :users  do |t|
+      t.timestamps null: false
+      t.string :email, null: false
+      t.string :name, null: false, default: ''
+    end
+
+    add_index :users, :email
+  end
+end


### PR DESCRIPTION
- Default non-presence-validated string fields to empty string to avoid nil values
- Put timestamps at the top when creating a table for consistency

Screenshot of db/schema with consistent use of timestamps at top:
![screen shot 2014-04-16 at 2 30 38 pm](https://cloud.githubusercontent.com/assets/601515/2725586/79a862ae-c5ae-11e3-9fc2-c0d4caed67db.png)

Screenshot of db/schema without consistent use of timestamps at top:

![screen shot 2014-04-16 at 2 31 03 pm](https://cloud.githubusercontent.com/assets/601515/2725593/8cff9480-c5ae-11e3-8670-d726e08ce158.png)
