### PR TITLE
Update README.md

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -341,7 +341,7 @@ Haskell
   imports last.
 * Use comma-first style exports, records, and lists.
 * Use four-space indentation except the `where` keyword which is 
-  indented two spaces [Example][where-example].
+  indented two spaces. [Example].
 
 [standard libraries]: http://www.haskell.org/ghc/docs/latest/html/libraries/index.html
-[where-example] https://github.com/thoughtbot/guides/blob/master/style/samples/haskell.hs#L46
+[Example]: https://github.com/thoughtbot/guides/blob/master/style/samples/haskell.hs#L41


### PR DESCRIPTION
Corrects link to the indentation example on the Haskell section.
