### PR TITLE
Do not use before_destroy and friends

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -69,6 +69,8 @@ Rails
 * Don't change a migration after it has been merged into master if the desired
   change can be solved with another migration.
 * Don't reference a model class directly from a view.
+* Don't return false from `ActiveModel` callbacks, but instead raise an
+  exception.
 * Don't use instance variables in partials. Pass local variables to partials
   from view templates.
 * Don't use SQL or SQL fragments (`where('inviter_id IS NOT NULL')`) outside of


### PR DESCRIPTION
We never check whether a `#destroy` fails in our controllers:

```
def destroy
  article = Article.find(params[:id])
  article.destroy
  redirect_to articles_url
end
```

Because of this history, it would cause confusion and potential bugs if
we introduced a `before_destroy` into any of our models. Not only will
we need to check the result of `#destroy` for any controller using that
model, but we'd also need to check the return value for any controller
using models that associate with that model.

This commit clearly states our stance on this: we do not expect a
`#destroy` to fail in a recoverable manner.
