### PR TITLE
Rule for trailing commas in multi-line lists

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -159,7 +159,11 @@ Ruby
 * Use `def self.method`, not `def Class.method` or `class << self`.
 * Use `def` with parentheses when there are arguments.
 * Use `each`, not `for`, for iteration.
+* Use a trailing comma after each item in a multi-line list, including the last
+  item. [Example][trailing comma example]
 * Use heredocs for multi-line strings.
+
+[trailing comma example]: /style/samples/ruby.rb#L45
 
 ERb
 ---

--- a/style/samples/ruby.rb
+++ b/style/samples/ruby.rb
@@ -38,8 +38,16 @@ class SomeClass
   def method_with_large_hash
     {
       :one => 'value',
-      :two => 'value'
+      :two => 'value',
     }
+  end
+
+  def method_with_large_array
+    [
+      :one,
+      :two,
+      :three,
+    ]
   end
 
   def invoke_method_with_arguments_on_multiple_lines


### PR DESCRIPTION
Without a trailing comma on the last item in a list, adding a new item causes
a deletion and two insertion in Git diffs.

With a trailing comma on the last item in a list, adding a new item causes
only one insertion and no deletions.
