### PR TITLE
Add fail/raise style guideline

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -162,6 +162,7 @@ Ruby
 * Use a trailing comma after each item in a multi-line list, including the last
   item. [Example][trailing comma example]
 * Use heredocs for multi-line strings.
+* Only use `raise` when re-raising exceptions. Otherwise use `fail`.
 
 [trailing comma example]: /style/samples/ruby.rb#L45
 


### PR DESCRIPTION
This style guideline was coined by @jimweirich and popularized by @avdi in his book "Exceptional Ruby". By using both `fail` and `raise` it is easier to discern whether the program is failing or simply re-raising an exception.
