### PR TITLE
Update style guide with HAML comment

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -179,6 +179,11 @@ HTML
 
 * Prefer double quotes for attributes.
 
+HAML
+----
+
+* Don't put content on the same line as the element that wraps it.
+
 Rails
 -----
 


### PR DESCRIPTION
I don't think I did a great job of explaining the following in the README, so here is a more complete description:

Prefer:

```
%p
  = post.body
```

to
`%p= post.body`

Why:
1. The code appears easier to read. 
2. The HTML is more consistent and easier to read. The HAML compiles into:

```
<p>
  This is some content of a post
</p>
```

`<p>This is some content of a post</p>`
