### PR TITLE
Prefer double quotes in Ruby

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -152,7 +152,7 @@ Ruby
 * Prefer `inject` over `reduce`.
 * Prefer `map` over `collect`.
 * Prefer `select` over `find_all`.
-* Prefer single quotes for strings.
+* Prefer double quotes for strings.
 * Prefer `&&` and `||` over `and` and `or`.
 * Use `_` for unused block parameters.
 * Use `%{}` for single-line strings needing interpolation and double-quotes.

--- a/style/samples/ruby.rb
+++ b/style/samples/ruby.rb
@@ -1,5 +1,5 @@
 class SomeClass
-  SOME_CONSTANT = 'upper case name'
+  SOME_CONSTANT = "upper case name"
 
   def initialize(attributes)
     @some_attribute = attributes[:some_attribute]
@@ -32,13 +32,13 @@ class SomeClass
   end
 
   def method_that_returns_a_hash
-    { :key => 'value' }
+    { :key => "value" }
   end
 
   def method_with_large_hash
     {
-      :one => 'value',
-      :two => 'value',
+      :one => "value",
+      :two => "value",
     }
   end
 


### PR DESCRIPTION
This will reduce the number of changes we have to make: when a string
transitions into something that needs interpolation, we do not need to
change the quotes.

This will also bring consistency to our writing: all strings will now
have double quotes, regardless of their contents.

It also puts us more in line with a large amount of external Ruby code,
which tends to use double quotes.
