### PR TITLE
Use RSpec's `allow` syntax instead of `stub`

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -241,11 +241,13 @@ Testing
 * Prefer `eq` to `==` in RSpec.
 * Separate setup, exercise, verification, and teardown phases with newlines.
 * Use RSpec's [`expect` syntax].
+* Use RSpec's [`allow` syntax] for method stubs.
 * Use `should` shorthand for [one-liners with an implicit subject].
 * Use `not_to` instead of `to_not` in RSpec expectations.
 * Prefer the `have_css` matcher to the `have_selector` matcher in Capybara assertions.
 
 [`expect` syntax]: http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
+[`allow` syntax]: https://github.com/rspec/rspec-mocks#method-stubs
 [one-liners with an implicit subject]: https://github.com/rspec/rspec-expectations/blob/master/Should.md#one-liners
 
 #### Acceptance Tests


### PR DESCRIPTION
`allow` was added to RSpec 2 along with `expect` as part of the move
away from `should` and `stub` which monkey-patched `Object`. It will be
the default in RSpec 3.
