### PR TITLE
Prefix branches with initials when solo

### DIFF
--- a/protocol/git/README.md
+++ b/protocol/git/README.md
@@ -24,7 +24,7 @@ Create a local feature branch based off master.
     git pull
     git checkout -b <branch-name>
 
-Prefix the branch name with your initials.
+When soloing, prefix the branch name with your initials.
 
 Rebase frequently to incorporate upstream changes.
 

--- a/style/README.md
+++ b/style/README.md
@@ -12,7 +12,7 @@ Git
 ---
 
 * Avoid merge commits by using a [rebase workflow].
-* Prefix feature branch names with your initials.
+* When soloing, prefix feature branch names with your initials.
 * Squash multiple trivial commits into a single commit.
 * Write a [good commit message].
 


### PR DESCRIPTION
When pairing, it is common to rotate pairs frequently. Often, the two
people that begin a branch are not the same people that continue working
on the branch. This leads to the branch name lying to everyone.

Therefore, I suggest that we don't need to add the initials to the
branch name when pairing.

One could argue that branches shouldn't last long enough to support a
pair swap. If that's true, then initial prefixing should be completely
unnecessary.
