### PR TITLE
Prefer leading dot for multi-line method calls

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -35,7 +35,7 @@ Formatting
 * Indent continued lines two spaces.
 * Indent private methods equal to public methods.
 * If you break up a chain of method invocations, keep each method invocation on
-  its own line. Place the `.` at the end of each line, except the last.
+  its own line. Place the `.` at the beginning of subsequent lines.
   [Example][dot guideline example].
 * Use 2 space indentation (no tabs).
 * Use an empty line between methods.

--- a/style/samples/ruby.rb
+++ b/style/samples/ruby.rb
@@ -8,9 +8,11 @@ class SomeClass
   end
 
   def method_with_arguments(argument_one, argument_two)
-    a_really_long_line_that_is_broken_up_over_multiple_lines_and.
-      subsequent_lines_are_indented_and.
-      each_method_lives_on_its_own_line
+    argument_one
+      .map(&:do_stuff)
+      .filter(&:some_predicate?)
+      .map(&:to_i)
+      .reduce(:+, 0)
   end
 
   def method_with_multiline_block


### PR DESCRIPTION
The same arguments apply here as for #167.

With a trailing dot on method calls broken across multiple lines, adding
an additional method call causes a deletion and two insertions in git
diffs.

Using a leading dot, adding an additional method call causes only a
single insertion, and the order can be freely moved without having to
worry about which call was the last line previously.
