### PR TITLE
Add guideline on symbol to_proc

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -156,6 +156,8 @@ Ruby
 * Prefer double quotes for strings.
 * Prefer `&&` and `||` over `and` and `or`.
 * Prefer `!` over `not`.
+* Prefer `&:method_name` to `{ |item| item.method_name }` for simple method
+  calls.
 * Use `_` for unused block parameters.
 * Use `%{}` for single-line strings needing interpolation and double-quotes.
 * Use `{...}` for single-line blocks. Use `do..end` for multi-line blocks.

--- a/style/samples/ruby.rb
+++ b/style/samples/ruby.rb
@@ -23,8 +23,12 @@ class SomeClass
     some_method_after_block(should_follow_after_newline)
   end
 
-  def method_with_single_line_block
-    items.map { |item| item.some_attribute }
+  def method_with_single_method_block
+    items.map(&:some_attribute)
+  end
+
+  def method_with_oneline_combined_methods_block
+    items.map { |item| "#{item.one} #{item.two}" }
   end
 
   def method_that_returns_an_array


### PR DESCRIPTION
- Using &:method_name is brief but clear
- Using it consistently aids readability
- Preferring simple method calls encourages simple methods
