### PR TITLE
Remove guide for using single mailer

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -226,7 +226,6 @@ Background Jobs
 Email
 -----
 
-* Use one `ActionMailer` for the app. Name it `Mailer`.
 * Use the user's name in the `From` header and email in the `Reply-To` when
   [delivering email on behalf of the app's users].
 


### PR DESCRIPTION
This is not a guideline we often follow. In addition, it's fairly
restrictive and leads to poor organization of information that could be
better expressed with proper naming. If anything this guide violates our
other guide for naming things to reveal intent.
