### PR TITLE
Change the restrictions for using self.

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -143,8 +143,8 @@ Ruby
 * Avoid explicit return statements.
 * Avoid using semicolons.
 * Avoid bang (!) method names. Prefer descriptive names.
-* Don't use `self` explicitly anywhere except for the following situations:
-  * class methods (`def self.method`)
+* Only use `self` in the following situations:
+  * class methods declarations (`def self.method`)
   * assignments (`self.attribute =`)
   * referencing the instance's class (`self.class`)
 * Prefer `detect` over `find`.

--- a/style/README.md
+++ b/style/README.md
@@ -143,8 +143,10 @@ Ruby
 * Avoid explicit return statements.
 * Avoid using semicolons.
 * Avoid bang (!) method names. Prefer descriptive names.
-* Don't use `self` explicitly anywhere except class methods (`def self.method`)
-  and assignments (`self.attribute =`).
+* Don't use `self` explicitly anywhere except for the following situations:
+  * class methods (`def self.method`)
+  * assignments (`self.attribute =`)
+  * referencing the instance's class (`self.class`)
 * Prefer `detect` over `find`.
 * Prefer `inject` over `reduce`.
 * Prefer `map` over `collect`.

--- a/style/README.md
+++ b/style/README.md
@@ -143,10 +143,7 @@ Ruby
 * Avoid explicit return statements.
 * Avoid using semicolons.
 * Avoid bang (!) method names. Prefer descriptive names.
-* Only use `self` in the following situations:
-  * class methods declarations (`def self.method`)
-  * assignments (`self.attribute =`)
-  * referencing the instance's class (`self.class`)
+* Only use self for assignments or when you need to explicitly reference the class.
 * Prefer `detect` over `find`.
 * Prefer `inject` over `reduce`.
 * Prefer `map` over `collect`.


### PR DESCRIPTION
Based on in office conversation the use of self to reference the class
has the potential benefit of handling renames in the event that the
class name needs to change. Additionally it makes for easier extraction
into a new class.