### PR TITLE
Add js- prefix to classes as well as ids that use javascript

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -100,7 +100,6 @@ Sass
 * Don't use ID's for style.
 * Use meaningful names: `$visual-grid-color` not `$color` or `$vslgrd-clr`.
 * Use ID and class names that are as short as possible but as long as necessary.
-* Prepend the prefix js- to IDs and classes that are used by Javascript.
 * Avoid using the direct descendant selector `>`.
 * Avoid nesting more than 4 selectors deep.
 * Don't nest more than 6 selectors deep.


### PR DESCRIPTION
The js- prefix doesn't need to be confined to be used to only id's. It can be just as useful to apply to classes in the event that the javascript happens more than once on a page.
