### PR TITLE
CoffeeScript preferred styles

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -132,6 +132,8 @@ CoffeeScript
 * Prefer `==` and `!=` to `is` and `isnt`
 * Prefer `||` and `&&` to `or` and `and`
 * Prefer `!` over `not`
+* Prefer `@` over `this` for referencing instance properties.
+* Prefer double quotes.
 
 Ruby
 ----


### PR DESCRIPTION
Prefer `@` over `this` for referencing instance properties

Prefer double quotes to preserve interpolation, allow for more complex strings,  make selectors easier to read and for overall consistency.
- `$("[data-role='title']")` or `$("input[type='text']")`
- `"Isn't this nice?"`
- `"It is #{nice}"`
