### PR TITLE
Prefer `protected` over `private` for non-public attributes

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -172,6 +172,8 @@ Ruby
 * Use a trailing comma after each item in a multi-line list, including the last
   item. [Example][trailing comma example]
 * Use heredocs for multi-line strings.
+* Prefer `protected` over `private` for non-public `attr_reader`s, `attr_writer`s,
+  and `attr_accessor`s.
 
 [trailing comma example]: /style/samples/ruby.rb#L45
 

--- a/style/samples/ruby.rb
+++ b/style/samples/ruby.rb
@@ -93,6 +93,12 @@ class SomeClass
     method_body
   end
 
+  protected
+
+  attr_reader :foo
+  attr_accessor :bar
+  attr_writer :baz
+
   private
 
   def complex_condition?


### PR DESCRIPTION
- With warnings enabled, private attributes cause a warning on MRI
  (doubly important for open source libaries, which should not emit
  warnings)
- Reduces churn when adding comparison or equality methods, since you'll
  likely need to access the attributes of the other object
- Reduces churn when adding a writer, since it is impossible to call
  private writer methods.
