### PR TITLE
Avoid checking boolean equality directly

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -265,6 +265,8 @@ Testing
 -------
 
 * Avoid the `private` keyword in specs.
+* Avoid checking boolean equality directly. Instead, write predicate methods and
+  use appropriate matchers. [Example][predicate-example].
 * Prefer `eq` to `==` in RSpec.
 * Separate setup, exercise, verification, and teardown phases with newlines.
 * Use RSpec's [`expect` syntax].
@@ -276,6 +278,7 @@ Testing
 [`expect` syntax]: http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
 [`allow` syntax]: https://github.com/rspec/rspec-mocks#method-stubs
 [one-liners with an implicit subject]: https://github.com/rspec/rspec-expectations/blob/master/Should.md#one-liners
+[predicate-example]: /style/samples/predicate_tests.rb
 
 #### Acceptance Tests
 

--- a/style/samples/predicate_tests.rb
+++ b/style/samples/predicate_tests.rb
@@ -1,0 +1,17 @@
+# Class under test:
+
+class Thing
+  def awesome?
+    true
+  end
+end
+
+# RSpec test:
+
+describe Thing, "#awesome?" do
+  it "is true" do
+    thing = Thing.new
+
+    expect(thing).to be_awesome
+  end
+end


### PR DESCRIPTION
- In RSpec 3, `be_false` and `be_true` are deprecated in favor of
  `be_falsey` and `be_truthy`
- Source: https://github.com/rspec/rspec-expectations/issues/283
- `be_falsy` works but is just an alias for `be_falsey` so we should prefer the
  latter
