### PR TITLE
Tweak guideline on multi-line method calls

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -29,7 +29,8 @@ Formatting
 * Don't misspell.
 * Don't vertically align tokens on consecutive lines.
 * If you break up an argument list, keep the arguments on their own lines and
-  closing parenthesis on its own line.
+  closing parenthesis on its own line. If the method takes an options hash, you
+  may place the first argument on the same line as the method call.
 * If you break up a hash, keep the elements on their own lines and closing curly
   brace on its own line.
 * Indent continued lines two spaces.

--- a/style/samples/ruby.rb
+++ b/style/samples/ruby.rb
@@ -51,15 +51,22 @@ class SomeClass
   end
 
   def invoke_method_with_arguments_on_multiple_lines
+    # Good
     some_method(
       i_am_a_long_variable_name_that_i_will_never_fit_on_one_line_with_others,
       two,
       three
     )
 
-    # Bad:
+    # Bad
     some_method(one,
                 two)
+
+    # This is okay
+    some_method(:foo,
+      first: 'option',
+      second: 'option'
+    )
   end
 
   def method_that_uses_infix_operators


### PR DESCRIPTION
Code like this is common but is currently against our guidelines:

``` ruby
FactoryGirl.build(:person,
  name: 'Steve',
  age: 10
)
```

``` ruby
Capybara::Poltergeist::Driver.new(app,
  inspector: true,
  timeout: 120
)
```
