### PR TITLE
Avoid `link_to` for non-GET requests.

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -204,6 +204,7 @@ Rails
 * Put application-wide partials in the [`app/views/application`] directory.
 * Use `def self.method`, not the `scope :method` DSL.
 * Use the default `render 'partial'` syntax over `render partial: 'partial'`.
+* Use `link_to` for GET requests, and `button_to` for other HTTP verbs.
 
 [`app/views/application`]: http://asciicasts.com/episodes/269-template-inheritance
 


### PR DESCRIPTION
This has come up in a few PRs I've reviewed recently, so I wanted to add it to the guides:
- Using `link_to` with the `method` option introduces an un-necessary dependency on JavaScript.
- HTML elements—in this case a form or a link—should be chosen for their semantics, not their appearance.
- CSS can be used to make links look like buttons and buttons look like links.
