### PR TITLE
using class(es) instead of object(s) where appropriate

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -21,7 +21,7 @@ Object-Oriented Design
 * Avoid global variables.
 * Avoid long parameter lists.
 * Limit collaborators of an object (entities an object depends on).
-* Limit the dependencies on a class(entities that depend on a class).
+* Limit an object's dependencies (entities that depend on an object).
 * Prefer composition over inheritance.
 * Prefer small methods. Between one and five lines is best.
 * Prefer small classes with a single, well-defined responsibility. When a


### PR DESCRIPTION
With reference to [Sandi Metz rules for developers](http://robots.thoughtbot.com/sandi-metz-rules-for-developers) and since [single responsibility principle](http://en.wikipedia.org/wiki/Single_responsibility_principle) sounds more appropriate when referred to a class as a whole, thus making appropriate changes. 

Please feel free to let me know your thoughts on this in case you think I'm missing something or I need to incorporate something else.

Thanks.
