### PR TITLE
Put parentheses around arguments

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -172,8 +172,11 @@ Ruby
 * Use a trailing comma after each item in a multi-line list, including the last
   item. [Example][trailing comma example]
 * Use heredocs for multi-line strings.
+* Put parentheses around arguments when calling a method with arguments.
+  [Example][paren example]
 
 [trailing comma example]: /style/samples/ruby.rb#L45
+[paren example]: /style/samples/calling_method.rb
 
 ERb
 ---

--- a/style/samples/calling_method.rb
+++ b/style/samples/calling_method.rb
@@ -1,0 +1,7 @@
+some_instance = SomeClass.new
+
+# Good:
+some_instance.method_with_arguments("arg_1", "arg 2")
+
+# Bad:
+some_instance.method_with_arguments "arg_1", "arg_2"


### PR DESCRIPTION
- When calling a method
- Existing guide only discusses method definition
