### PR TITLE
Use double quotes for Sass

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -81,9 +81,8 @@ Sass
 * Prefer hex color codes `#000`.
 * Use `//` for comment blocks not `/* */`.
 * Use a space between selector and `{`.
-* Use single quotation marks for attribute selectors and property values.
+* Use double quotation marks.
 * Use only lowercase, including colors.
-* Use single quotes, including imports.
 * Don't add a unit specification after `0` values, unless required by a mixin.
 * Use space around operands: `$variable * 1.5`, not `$variable*1.5`
 * Avoid in-line operations in shorthand declarations (Ex. `padding: $variable * 1.5 variable * 2`)

--- a/style/samples/sass.scss
+++ b/style/samples/sass.scss
@@ -1,3 +1,5 @@
+@import "bourbon";
+
 section.application {
   @extend %extend;
   @include mixin;
@@ -15,12 +17,15 @@ section.application {
     attribute: value;
   }
 
+  &:before {
+    content: ">";
+  }
+
   .news {
     attribute: value;
     attribute: ($variable * 1.5) 2em;
 
     article {
-
       @extend media(value) {
         attribute: value;
       }


### PR DESCRIPTION
I find it both confusing and irritating to have different conventions for Sass, Coffeescript and Ruby as far as quotation marks go. The same arguments apply for Sass, so there is no reason we make it the exception.
