### PR TITLE
Fix broken link in "Rails Migrations"

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -234,8 +234,7 @@ Rails Migrations
 ----------------
 * Set an empty string as the default constraint for non-required string and text
   fields. [Example][default example].
-* List timestamps first when creating a new table. [Example][timestamps
-  example].
+* List timestamps first when creating a new table. [Example][timestamps example].
 
 [timestamps example]: /style/samples/migration.rb
 [default example]: /style/samples/migration.rb#L6


### PR DESCRIPTION
GitHub wasn't displaying the markdown link correctly with a line break here.
