### PR TITLE
Use `is_expected.to` instead of `should`

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -270,13 +270,13 @@ Testing
 * Separate setup, exercise, verification, and teardown phases with newlines.
 * Use RSpec's [`expect` syntax].
 * Use RSpec's [`allow` syntax] for method stubs.
-* Use `should` shorthand for [one-liners with an implicit subject].
+* Use `is_expected.to` for [one-liners with an implicit subject].
 * Use `not_to` instead of `to_not` in RSpec expectations.
 * Prefer the `have_css` matcher to the `have_selector` matcher in Capybara assertions.
 
 [`expect` syntax]: http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
 [`allow` syntax]: https://github.com/rspec/rspec-mocks#method-stubs
-[one-liners with an implicit subject]: https://github.com/rspec/rspec-expectations/blob/master/Should.md#one-liners
+[one-liners with an implicit subject]: http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new_api_for_oneliners_
 
 #### Acceptance Tests
 

--- a/style/samples/testing.rb
+++ b/style/samples/testing.rb
@@ -1,6 +1,6 @@
 describe SomeClass do
-  it { should have_one(:association) }
-  it { should validate_presence_of(:some_attribute) }
+  it { is_expected.to have_one(:association) }
+  it { is_expected.to validate_presence_of(:some_attribute) }
 
   describe '.some_class_method' do
     it 'does something' do


### PR DESCRIPTION
Even though we've switched to the `expect` syntax, we've still been using
`should` for one-liners with an implicit subject. RSpec 3 introduced
`is_expected.to` as an alternative. Myron Marston explains:

> Some users have expressed confusion about how this should relates to the
> expect syntax and if you can continue using it. It will continue to be
> available in RSpec 3 (again, regardless of your syntax configuration), but
> we’ve also added an alternate API that is a bit more consistent with the
> expect syntax

From: [New API for
one-liners](http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new_api_for_oneliners_)
