### PR TITLE
Add CoffeeScript colon assignment spaces guideline

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -128,6 +128,8 @@ Sass
 CoffeeScript
 ------------
 
+[Sample](samples/coffee.coffee)
+
 * Avoid conditional modifiers (lines that end with conditionals).
 * Avoid backticks.
 * Initialize arrays using `[]`.
@@ -141,6 +143,8 @@ CoffeeScript
 * Use `PascalCase` for classes, `lowerCamelCase` for variables and functions,
   `SCREAMING_SNAKE_CASE` for constants, `_single_leading_underscore` for
   private variables and functions.
+* Use zero spaces before and one space after the colon in a colon assignment
+  (i.e. classes, objects).
 
 Backbone
 --------

--- a/style/samples/coffee.coffee
+++ b/style/samples/coffee.coffee
@@ -1,0 +1,4 @@
+object = { spacing: true }
+
+class Cat
+  canBark: false


### PR DESCRIPTION
This can be enforced in Hound with the `colon_assignment_spacing` option in
CoffeeLint.

http://www.coffeelint.org/#options
