### PR TITLE
Don't use backticks in CoffeeScript

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -129,17 +129,18 @@ CoffeeScript
 ------------
 
 * Avoid conditional modifiers (lines that end with conditionals).
+* Avoid backticks.
 * Initialize arrays using `[]`.
 * Initialize empty objects and hashes using `{}`.
-* Use hyphen-separated filenames, such as `coffee-script.coffee`.
-* Use `PascalCase` for classes, `lowerCamelCase` for variables and functions,
-  `SCREAMING_SNAKE_CASE` for constants, `_single_leading_underscore` for
-  private variables and functions.
 * Prefer `==` and `!=` to `is` and `isnt`
 * Prefer `||` and `&&` to `or` and `and`
 * Prefer `!` over `not`
 * Prefer `@` over `this` for referencing instance properties.
 * Prefer double quotes.
+* Use hyphen-separated filenames, such as `coffee-script.coffee`.
+* Use `PascalCase` for classes, `lowerCamelCase` for variables and functions,
+  `SCREAMING_SNAKE_CASE` for constants, `_single_leading_underscore` for
+  private variables and functions.
 
 Backbone
 --------


### PR DESCRIPTION
Backticks allow snippets of JavaScript to be embedded in CoffeeScript. While
some folks consider backticks useful in a few niche circumstances, they should
be avoided because so none of JavaScript's "bad parts", like <tt>with</tt> and
<tt>eval</tt>, sneak into CoffeeScript.

This can be enforced by Hound with the `no_backticks` option in CoffeeLint,
which is enabled by default.

http://www.coffeelint.org/#options

Also: alphabetize the CoffeeScript guidelines.
