### PR TITLE
Add convention for time without date columns

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -217,6 +217,7 @@ Rails
 * Use private instead of protected when defining controller methods.
 * Name date columns with `_on` suffixes.
 * Name datetime columns with `_at` suffixes.
+* Name time columns (referring to a time of day with no date) with `_time` suffixes.
 * Name initializers for their gem name.
 * Order ActiveRecord associations alphabetically by attribute name.
 * Order ActiveRecord validations alphabetically by attribute name.


### PR DESCRIPTION
Rails returns times without dates from the database as `Time` objects (as a
time on the date `2000-01-01` in UTC), which can lead to confusion with
actual datetimes. Although we can't make the returned value clearer,
uniformly naming these columns with the suffix `_time` can at least remove
confusion while reading the code.