### PR TITLE
Add guideline for multiple stubs on an object

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -276,12 +276,15 @@ Testing
 * Separate setup, exercise, verification, and teardown phases with newlines.
 * Use RSpec's [`expect` syntax].
 * Use RSpec's [`allow` syntax] for method stubs.
+* Use RSpec's `receive_messages` for multiple method stubs on a single object
+  (available in RSpec 3). [Example][single line syntax example].
 * Use `should` shorthand for [one-liners with an implicit subject].
 * Use `not_to` instead of `to_not` in RSpec expectations.
 * Prefer the `have_css` matcher to the `have_selector` matcher in Capybara assertions.
 
 [`expect` syntax]: http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
 [`allow` syntax]: https://github.com/rspec/rspec-mocks#method-stubs
+[single line syntax example]: /style/samples/allow_syntax_spec.rb
 [one-liners with an implicit subject]: https://github.com/rspec/rspec-expectations/blob/master/Should.md#one-liners
 [predicate-example]: /style/samples/predicate_tests.rb
 

--- a/style/samples/allow_syntax_spec.rb
+++ b/style/samples/allow_syntax_spec.rb
@@ -1,0 +1,11 @@
+describe User do
+  # preferred way to stub multiple methods
+
+  it "uses single line allow syntax for multiple stubs on an object" do
+    user = create(:user)
+    allow(user).to receive_messages(age: 11, first_name: "Ralph")
+
+    expect(user.age).to eq 11
+    expect(user.first_name).to eq "Ralph"
+  end
+end


### PR DESCRIPTION
- `receive_messages` is available in RSpec 3
- Reference: https://github.com/thoughtbot/guides/pull/175#issuecomment-43917785
