### PR TITLE
Add guideline for creating mutable collections

### DIFF
--- a/style/samples/Swift.swift
+++ b/style/samples/Swift.swift
@@ -24,6 +24,15 @@ let cool = yTown(5) { foo in
     }
 }
 
+// Variable/Constant Instantiation
+
+// Use type inference where the end result is obvious
+let foo = "foo"
+
+// Explicitly type collections when creating mutable empty instances
+var collection: [Object] = []
+var dictionary: [String: Object] = [:]
+
 // Optionals -----------------------------------------------------------
 
 var maybe: Bool?
@@ -41,7 +50,7 @@ func tableView(tableView: UITableView!, cellForRowAtIndexPath indexPath: NSIndex
             return cell;
         }
     }
-    
+
     return .None
 }
 


### PR DESCRIPTION
The alternative syntax is:

``` swift
var collection = [Object]()
```

I find this syntax jarring because of the visual combination of the braces and
the parens. It also seems to be taking a too-rigid stance in favor of using
type inference. I believe that the proposed syntax lets you type the object,
and then be explicit about creating an empty array, which will then by typed
appropriately.
