### PR TITLE
Prefer an object over a hash, whenever the keys are significant

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -41,6 +41,8 @@ Ruby
   multiple models.
 * Prefer `private` when indicating scope. Use `protected` only with comparison
   methods like `def ==(other)`, `def <(other)`, and `def >(other)`.
+* Prefer (named) value objects over plain arrays and hashes to hold
+  domain-specific data.
 
 [Bundler binstubs]: https://github.com/sstephenson/rbenv/wiki/Understanding-binstubs
 


### PR DESCRIPTION
In general, any time you're working with a hash that has specific keys
(e.g. accessed with a literal), you've likely got an object wanting to
get out, even if it's just a struct with no other methods. The biggest
upside is more meaningful errors if you have a typo, since the default
behavior of a hash is to return nil. Cases where you don't care about
specific keys (e.g. using a hash to memoize a single argument method)
are fine.
