### PR TITLE
Include `href` or `to_param` when constructing URLs client side

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -187,6 +187,8 @@ JavaScript
 ----------
 * Use Coffeescript, ES6 with [babel], or another language that compiles to
   JavaScript
+* Include a `to_param` or `href` attribute when serializing ActiveRecord models,
+  and use that when constructing URLs client side, rather than the ID. Example:
 
 [babel]: http://babeljs.io/
 

--- a/best-practices/samples/handlebars.hbs
+++ b/best-practices/samples/handlebars.hbs
@@ -1,0 +1,5 @@
+<!-- Use toParam when constructing URLs, not ID -->
+<!-- Good -->
+<a href="/posts/{{ post.toParam }}">
+<!-- Bad -->
+<a href="/posts/{{ post.id }}">

--- a/best-practices/samples/ruby.rb
+++ b/best-practices/samples/ruby.rb
@@ -1,0 +1,6 @@
+# Include an href or to_param attribute when serializing models
+class PostSerializer < ActiveModel::Serializer
+  attributes :id, :content, :to_param
+
+  delegate :to_param, to: :object
+end


### PR DESCRIPTION
One nice feature that Rails provides is easy changes to URL generation
(assuming the param starts with the ID). All you have to do is

```ruby
def to_param
  [id, name].to_param
end
```

and everything "Just Works". This is lost, however, if you're manually
constructing URLs on the client side. This is avoided, if as a general
rule of thumb, we let the server decide how to construct the URLs, and
pass that information along.