### PR TITLE
Add style guide for order of properties in Android views

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -411,5 +411,12 @@ Haskell
 * Use four-space indentation except the `where` keyword which is
   indented two spaces. [Example].
 
+Android
+-------
+
+* Properties of views should be alphabetized, with the exception of `id`,
+  `layout_width`, and `layout_height` which should be placed first in that
+  order.
+
 [standard libraries]: http://www.haskell.org/ghc/docs/latest/html/libraries/index.html
 [Example]: /style/samples/haskell.hs#L41

--- a/style/samples/android_layout.xml
+++ b/style/samples/android_layout.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  >
+  <TextView
+    android:id="@+id/system_name"
+    android:layout_height="48sp"
+    android:layout_width="match_parent"
+    android:background="@color/brand_red"
+    android:gravity="center_vertical"
+    android:layout_alignBottom="@id/system_image"
+    android:layout_alignLeft="@id/system_image"
+    android:paddingLeft="12dp"
+    android:textColor="@color/base_font_color"
+    android:textSize="18sp"
+    />
+</LinearLayout>


### PR DESCRIPTION
Alphabetized is pretty much the standard, but we felt that `id`,
`layout_width`, and `layout_height` should be listed first. `id` is
the property you care about most (if it is present), and should be
quick to find at a glance. `layout_width` and `layout_height` are
required on all views, and affect the layout of the view most, so they
should also be separated from the rest.
