### PR TITLE
Use double colons for pseudo-elements

### DIFF
--- a/style/samples/sass.scss
+++ b/style/samples/sass.scss
@@ -17,7 +17,11 @@ section.application {
     attribute: value;
   }
 
-  &:before {
+  &::before {
+    content: "<";
+  }
+
+  &::after {
     content: ">";
   }
 


### PR DESCRIPTION
Use double colons (::) for pseudo-elements, like ::before, ::after.
Use single colon (:) for pseudo-class, like :hover, :checked.

More at:
https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements
https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
https://developer.mozilla.org/en-US/docs/Web/CSS/::before