### PR TITLE
Prefer more common enumerable method names

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -176,10 +176,10 @@ Ruby
 * Avoid bang (!) method names. Prefer descriptive names.
 * Don't use `self` explicitly anywhere except class methods (`def self.method`)
   and assignments (`self.attribute =`).
-* Prefer `detect` over `find`.
-* Prefer `inject` over `reduce`.
+* Prefer `find` over `detect`.
+* Prefer `find_all` over `select`.
 * Prefer `map` over `collect`.
-* Prefer `select` over `find_all`.
+* Prefer `reduce` over `inject`.
 * Prefer double quotes for strings.
 * Prefer `&&` and `||` over `and` and `or`.
 * Prefer `!` over `not`.


### PR DESCRIPTION
We had historically favored the `*ect` enumerable methods (`select`,
`detect`, `inject`, `collect`) because, uh, they rhymed. At some point we
changed to preferring `map` over collect and now it's time to finish the job.

`find`, `find_all`, and `reduce` are all available in Ruby and those names are
more consistent with other languages.  They also have the advantage of
sounding distinct from the previous method names which makes them easier to
differentiate for people new to them.
