### PR TITLE
Use `ENV.fetch` instead of `ENV[]`

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -93,6 +93,8 @@ Rails
 * Prefer `Time.current` over `Time.now`
 * Prefer `Date.current` over `Date.today`
 * Prefer `Time.zone.parse("2014-07-04 16:05:37")` over `Time.parse("2014-07-04 16:05:37")`
+* Use `ENV.fetch` for environment variables instead of `ENV[]`so that unset
+  environment variables are detected on deploy.
 
 [`.ruby-version`]: https://gist.github.com/fnichol/1912050
 [redirects]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30


### PR DESCRIPTION
It's easy to forget to set environment variables (e.g. `AWS_SECRET_KEY`) on 
staging or production. Using `ENV.fetch("AWS_SECRET_KEY")` ensures that
missing environment variables raise errors instead of just being `nil`.

Heroku boots the app on deploy, which runs the app's initializers. Often, 
environment variables are set in an initializer. This combination means that
if an environment variable isn't set, an error will be raised and Heroku will
abort the deploy. This means users can never see a version of the app without
the environment variables set.
