### PR TITLE
Remove typo from long variable name in ruby.rb

### DIFF
--- a/style/samples/ruby.rb
+++ b/style/samples/ruby.rb
@@ -60,7 +60,7 @@ class SomeClass
 
   def invoke_method_with_arguments_on_multiple_lines
     some_method(
-      i_am_a_long_variable_name_that_i_will_never_fit_on_one_line_with_others,
+      i_am_a_long_variable_name_that_will_never_fit_on_one_line_with_others,
       two,
       three
     )


### PR DESCRIPTION
Change `i_am_a_long_variable_name_that_i_will_never_fit_on_one_line_with_others`
to           `i_am_a_long_variable_name_that_will_never_fit_on_one_line_with_others`
