### PR TITLE
Only follow a guideline if you understand it

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -6,6 +6,8 @@ A guide for programming well.
 General
 -------
 
+* These are not to be blindly followed; strive to understand these and ask
+  when in doubt.
 * Don't duplicate the functionality of a built-in library.
 * Don't swallow exceptions or "fail silently."
 * Don't write code that guesses at future functionality.


### PR DESCRIPTION
The guidelines are short, pithy reminders for those with experience. It
came out of a desire to stop debating the same old topics such as
indentation, `#collect` vs `#map`, quoting, `save(false)`, and so many
more.

As such, it is useful for those who understood the debate, what it
meant, and what compromises and trade-offs were made. The justification
for an action should never be "there's a guideline for it" --- that's
begging the question. Instead, once an action is justified, a guideline
can usefully be made.

Think of these more like notes than rules.

This commit comes with a statement about the desired culture around the
guides: a style violation is caught by Hound as normal, but a best
practice violation is a discussion about the tradeoffs that go into such
a violation.
