### PR TITLE
Add best practice to prefer Lo-dash/Underscore

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -178,7 +178,15 @@ Email
 JavaScript
 ----------
 
+* Prefer utility methods from common libraries like [Lo-Dash]/[Underscore.js]
+  over methods that do the same thing from frameworks like
+  [Angular.js]/[Ember.js].
 * Use CoffeeScript.
+
+[Lo-Dash]: https://lodash.com
+[Underscore.js]: http://underscorejs.org
+[Angular.js]: https://angularjs.org
+[Ember.js]: https://emberjs.com
 
 HTML
 ----


### PR DESCRIPTION
There are certain utility methods that exist in both Lo-dash/Underscore as well
as in a framework like AngularJS. We should prefer the former, because they are
smaller, well-focused, widely used libraries. This will avoid us from coupling
our code to a framework.

Example:
```js
// prefer

_.merge(object1, object2);

// over

angular.extend(object1, object2);
```