### PR TITLE
Add guideline for using described_class

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -287,6 +287,7 @@ Testing
 * Separate setup, exercise, verification, and teardown phases with newlines.
 * Use RSpec's [`expect` syntax].
 * Use RSpec's [`allow` syntax] for method stubs.
+* Use `described_class` instead of directly referring to the class under test.
 * Use `should` shorthand for [one-liners with an implicit subject].
 * Use `not_to` instead of `to_not` in RSpec expectations.
 * Prefer the `have_css` matcher to the `have_selector` matcher in Capybara assertions.


### PR DESCRIPTION
The `described_class` method in RSpec returns the class passed to the outer-most `describe` block. Using it makes it significantly easier to rename classes.

I was using this in some unit specs in gitsh, but not in others. When @mike-burns and I did some restructuring and moved a bunch of classes around, it was much easier for the specs that were already using `described_class` (see: https://github.com/thoughtbot/gitsh/commit/c1dc545c21a8037f47d71bf8ca01e667433f6d6e).

Documentation: https://www.relishapp.com/rspec/rspec-core/docs/metadata/described-class