### PR TITLE
Only make positive assertions in Capybara specs

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -110,6 +110,8 @@ Testing
 * Disable real HTTP requests to external services with
   `WebMock.disable_net_connect!`.
 * Don't test private methods.
+* Don't use `expect().not_to` in Capybara specs.
+  Use `expect().to` and the `have_no_*` matchers.
 * Test background jobs with a [`Delayed::Job` matcher].
 * Use [stubs and spies] \(not mocks\) in isolated tests.
 * Use a single level of abstraction within scenarios.


### PR DESCRIPTION
`expect().not_to` causes Capybara to wait until it times out before running
your matcher.

From an old internal document from @djcp.
