### PR TITLE
Don't include header comments in swift

### DIFF
--- a/style/samples/Swift.swift
+++ b/style/samples/Swift.swift
@@ -1,3 +1,4 @@
+// Don't include generated header comments
 
 import Foundation // or not
 
@@ -41,7 +42,7 @@ func tableView(tableView: UITableView!, cellForRowAtIndexPath indexPath: NSIndex
             return cell;
         }
     }
-    
+
     return .None
 }
 
@@ -62,4 +63,3 @@ case let .Success(data):
 case let .Failure(error):
     println("An error occured: \(error)")
 }
-


### PR DESCRIPTION
I'd really like to leave these comments behind. Thoughts?
