### PR TITLE
Add example of type inference in swift functions

### DIFF
--- a/style/samples/Swift.swift
+++ b/style/samples/Swift.swift
@@ -53,8 +53,13 @@ enum Response {
     case Failure(NSError)
 }
 
-// when the type is known you can let the compiler infer
+// When the type is known you can let the compiler infer
 let response: Response = .Success(NSData())
+
+func doSomeWork() -> Response {
+    let data = ...
+    return .Success(data)
+}
 
 switch response {
 case let .Success(data):


### PR DESCRIPTION
I think this is another non-obvious example of where type inference is
awesome. @thoughtbot/ios
