### PR TITLE
Sass: Prefer mixins to @extends

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -204,6 +204,7 @@ Sass
   display scrollbars outside of OS X, even when content fits in the container.
 * Use `image-url` and `font-url`, not `url`, so the asset pipeline will re-write
   the correct paths to assets.
+* Prefer mixins to `@extend`.
 
 Browsers
 --------


### PR DESCRIPTION
Extends can cause long, unwieldy selectors if not minded. Compiled file
size is negligible with Gzip. Extending doesn't work across media
queries, and can't gracefully accept arguments.

Further discussion at https://github.com/thoughtbot/bitters/pull/140