### PR TITLE
Don't shadow outer variables

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -55,6 +55,8 @@ Naming
 
 * Avoid abbreviations.
 * Avoid object types in names (`user_array`, `email_method` `CalculatorClass`, `ReportModule`).
+* Don't "shadow" variables.
+  Name variables in inner scopes differently than variables in outer scopes.
 * Prefer naming classes after domain concepts rather than patterns they
   implement (e.g. `Guest` vs `NullUser`, `CachedRequest` vs `RequestDecorator`).
 * Name the enumeration parameter the singular of the collection.


### PR DESCRIPTION
This guideline is already in effect in Hound's default .ruby.yml file, used by
Rubocop:

https://github.com/thoughtbot/hound/blob/master/config/style_guides/ruby.yml

It is possible in many programming languages to name variables the same as the
name of other variables in a different lexical scope. This is called "variable
shadowing."

Shadowing variables can be convenient but can also cause confusion and are
easy to catch with tools such as Hound and Syntastic.

http://wizardmode.com/2012/06/shadowing-variables-in-coffeescript/ 
https://books.google.com/books?id=HW-5SZ1HKusC&lpg=PA189&ots=Fq462aV4rp&dq=shadow%20outer%20variable&pg=PA189#v=onepage&q=shadow%20outer%20variable&f=false 
http://rustbyexample.com/variables/scope.html

With `$VERBOSE = true` turned on in Ruby, the language will print a warning.

https://stackoverflow.com/questions/6259314/what-does-shadowing-mean-in-ruby`