### PR TITLE
Add guide for Sass color functions

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -1,39 +1,36 @@
-Sass
-====
+# Sass
 
 [Sample](sample.scss)
 
-Formatting
-----------
+## Formatting
 
-* Use the *Scss* syntax.
+* Use the SCSS syntax.
 * Use hyphens when naming mixins, extends, classes, functions & variables: `span-columns` not `span_columns` or `spanColumns`.
-* Use space between property and value: `width: 20px` not `width:20px`.
-* Use a blank line above selector that has styles.
-* Prefer hex color codes `#000`.
+* Use one space between property and value: `width: 20px` not `width:20px`.
+* Use a blank line above a selector that has styles.
+* Prefer hex color codes `#fff`.
 * Use `//` for comment blocks not `/* */`.
-* Use a space between selector and `{`.
+* Use one space between selector and `{`.
 * Use double quotation marks.
 * Use only lowercase, including colors.
 * Don't add a unit specification after `0` values, unless required by a mixin.
 * Use a leading zero in decimal numbers: `0.5` not `.5`
 * Use space around operands: `$variable * 1.5`, not `$variable*1.5`
 * Avoid in-line operations in shorthand declarations (Ex. `padding: $variable * 1.5 variable * 2`)
-* Use parentheses around individual operations in shorthand declarations: `padding: ($variable * 1.5) ($variable * 2)`
+* Use parentheses around individual operations in shorthand declarations: `padding: ($variable * 1.5) ($variable * 2);`
 * Use double colons for pseudo-elements
+* Use a `%` unit for the amount/weight when using Sass's color functions: `darken($color, 20%)`, not `darken($color, 20)`
 
-Order
------
+## Order
 
 * Use alphabetical order for declarations.
-* Place @extends and @includes at the top of your declaration list.
+* Place `@extends` and `@includes` at the top of your declaration list.
 * Place media queries directly after the declaration list.
 * Place concatenated selectors second.
 * Place pseudo states and elements third.
 * Place nested selectors last.
 
-Selectors
----------
+## Selectors
 
 * Don't use ID's for style.
 * Use meaningful names: `$visual-grid-color` not `$color` or `$vslgrd-clr`.
@@ -48,12 +45,11 @@ Selectors
 * Avoid using comma delimited selectors.
 * Avoid nesting within a media query.
 
-Organization
-------------
+## Organization
 
-* Use Bourbon for a Sass Library.
+* Use Bourbon for a Sass library.
 * Use Neat for a grid framework.
-* Use Bitters / Base folder for style on HTML tags, global variables, global extends and global mixins.
-* Use Normalize as a browser reset.
+* Use Bitters/`base` directory for styling element selectors, global variables, global extends and global mixins.
+* Use [Normalize](https://github.com/necolas/normalize.css) for browser rendering consistency, rather than a reset.
 * Use HTML structure for ordering of selectors. Don't just put styles at the bottom of the Sass file.
 * Avoid having files longer than 100 lines.


### PR DESCRIPTION
Addition: Use a `%` for the amount/weight, when using Sass’s color functions: `darken($color, 20%)`, not `darken($color, 20)`

I also fixed some grammar and formatting issues.

@thoughtbot/design Thoughts?