### PR TITLE
Remove guideline for recommended css file structure.

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -55,5 +55,4 @@ Organization
 * Use Bitters / Base folder for style on HTML tags, global variables, global extends and global mixins.
 * Use Normalize as a browser reset.
 * Use HTML structure for ordering of selectors. Don't just put styles at the bottom of the Sass file.
-* Prefer the same file structure that is found in app/views.
 * Avoid having files longer than 100 lines.


### PR DESCRIPTION
I don't think this is considered a best practice anymore, and this isn't a guideline I follow. File structure for CSS is moving towards styling modules/components that can be reused anywhere vs. per page or view. This can cut down on repeated code for similar styles across views, and also helps maintain consistency in design across a site. 