### PR TITLE
Update guide to reflect background-color style

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -9,6 +9,7 @@
 * Use one space between property and value: `width: 20px` not `width:20px`.
 * Use a blank line above a selector that has styles.
 * Prefer hex color codes `#fff`.
+* Avoid using shorthand properties for only one value: `background-color: #ff0000;`, not `background: #ff0000;`
 * Use `//` for comment blocks not `/* */`.
 * Use one space between selector and `{`.
 * Use double quotation marks.


### PR DESCRIPTION
I was talking to @creuter yesterday about this. When only specifying a background color use `background-color` vs `background` - seems more "proper." `background` feels more appropriate when using background shorthand.

I wasn't sure where else to make the note. I added it as a comment (that may be a bad thing).
Thoughts on this?