### PR TITLE
Do not put timestamps at the top of a migration

### DIFF
--- a/style/rails/README.md
+++ b/style/rails/README.md
@@ -30,9 +30,7 @@ Migrations
 
 * Set an empty string as the default constraint for non-required string and text
   fields. [Example][default example].
-* List timestamps first when creating a new table. [Example][timestamps example].
 
-[timestamps example]: migration.rb
 [default example]: migration.rb#L6
 
 Routes


### PR DESCRIPTION
`rails generate` puts timestamps at the bottom of a migration by default, 
meaning we have to change every migration even if the migration is otherwise 
generated perfectly.

Original discussion: https://github.com/thoughtbot/guides/pull/159