### PR TITLE
Added IE8 to list of browsers to not support

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -210,7 +210,7 @@ Browsers
 --------
 
 * Don't support clients without Javascript.
-* Don't support IE6 or IE7.
+* Don't support IE6, IE7, or IE8.
 
 Objective-C
 -----------


### PR DESCRIPTION
Considering [Microsofts announcement](http://blogs.windows.com/bloggingwindows/2015/01/21/the-next-generation-of-windows-windows-10/) for a new [web experience](http://gizmodo.com/microsofts-spartan-browser-is-here-to-save-you-from-int-1680879010) in Windows 10, IE8 is becoming even more deprecated.

Included IE8 to the list of browsers not to support.