### PR TITLE
Replace mail preview statement for Rails

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -173,12 +173,13 @@ Email
 
 * Use [SendGrid] or [Amazon SES] to deliver email in staging and production
   environments.
-* Use a tool like [MailView] to look at each created or updated mailer view
-  before merging.
+* Use a tool like [ActionMailer Preview] to look at each created or updated mailer view
+  before merging. Use [MailView] gem unless using Rails version 4.1.0 or later.
 
 [Amazon SES]: http://robots.thoughtbot.com/post/3105121049/delivering-email-with-amazon-ses-in-a-rails-3-app
 [SendGrid]: https://devcenter.heroku.com/articles/sendgrid
 [MailView]: https://github.com/37signals/mail_view
+[ActionMailer Preview]: http://api.rubyonrails.org/v4.1.0/classes/ActionMailer/Base.html#class-ActionMailer::Base-label-Previewing+emails
 
 JavaScript
 ----------


### PR DESCRIPTION
Nice project; handy list of best practices :+1: 

This PR just updates the Rails mail preview point to say that ActionMailer Preview is available in Rails 4.1.0 or later now and you can still use the MailView gem if on an older version of Rails.