### PR TITLE
Prefer `+` over `\` for concatenating long strings

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -38,6 +38,7 @@ Ruby
 * Use heredocs for multi-line strings.
 * Prefer `protected` over `private` for non-public `attr_reader`s, `attr_writer`s,
   and `attr_accessor`s.
+* Prefer `+` over `\` for concatenating strings.
 
 [trailing comma example]: /style/ruby/sample.rb#L49
 [required kwargs]: /style/ruby/sample.rb#L16


### PR DESCRIPTION
In Ruby, `"a" "b" == "ab"`, i.e. whitespace can be used to concatenate strings. Due to this, the following can be used to concatenate strings:

```ruby
"hello" \
"world"
```

It is equivalent to `"hello" "world"`.

But we don't ever write `"hello" "world"`, we write `"hello" + "world"` and rely on `String#+` instead of niche syntax. Therefore we should use `+` to concatenate multi-line strings as well:

```ruby
"hello" +
  "world"
```