### PR TITLE
Add JavaScript style guide

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -185,8 +185,10 @@ Email
 
 JavaScript
 ----------
+* Use Coffeescript, ES6 with [babel], or another language that compiles to
+  JavaScript
 
-* Use CoffeeScript.
+[babel]: http://babeljs.io/
 
 HTML
 ----

--- a/style/README.md
+++ b/style/README.md
@@ -20,6 +20,7 @@ detailed, language/framework-specific style guides:
 * [Git](git)
 * [Haskell](haskell)
 * [HTML](html)
+* [JavaScript](javascript)
 * [Objective C](objective_c)
 * [Python](python)
 * [Rails](rails)

--- a/style/javascript/README.md
+++ b/style/javascript/README.md
@@ -1,0 +1,24 @@
+JavaScript
+==========
+
+[Sample](sample.js)
+
+* Prefer ES6 classes over prototypes.
+* Use strict equality checks (`===` and `!==`) except when comparing against
+  (`null` or `undefined`).
+* Prefer [arrow functions] `=>`, over the `function` keyword except when
+  defining classes or methods.
+* Use semicolons at the end of each statement.
+* Prefer double quotes.
+* Use `PascalCase` for classes, `lowerCamelCase` for variables and functions,
+  `SCREAMING_SNAKE_CASE` for constants, `_singleLeadingUnderscore` for private
+  variables and functions.
+* Prefer [template strings] over string concatenation.
+* Prefer promises over callbacks.
+* Prefer array functions like `map` and `forEach` over `for` loops.
+* Use `const` for declaring variables that will never be re-assigned, and `let`
+  otherwise.
+* Avoid `var` to declare variables.
+
+[template strings]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings
+[arrow functions]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions

--- a/style/javascript/sample.js
+++ b/style/javascript/sample.js
@@ -1,0 +1,7 @@
+object = { spacing: true }
+
+class Cat {
+  canBark() {
+    return false;
+  }
+}


### PR DESCRIPTION
This is the first shot at a JavaScript style guide to get us talking about what should go in it. I've also replaced "Use CoffeeScript" from best practices with "Use ES6" (but sightly longer). A good bit of this echoes the CoffeeScript guides, but that's expected.

I also need to try and expand on `sample.js`.