### PR TITLE
Clarify how Rails associations should be ordered

### DIFF
--- a/style/rails/README.md
+++ b/style/rails/README.md
@@ -8,7 +8,8 @@ Rails
 * Name time columns (referring to a time of day with no date) with `_time`
   suffixes.
 * Name initializers for their gem name.
-* Order ActiveRecord associations alphabetically by attribute name.
+* Order ActiveRecord associations alphabetically by association type, then
+  attribute name.
 * Order ActiveRecord validations alphabetically by attribute name.
 * Order ActiveRecord associations above ActiveRecord validations.
 * Order controller contents: filters, public methods, private methods.

--- a/style/rails/README.md
+++ b/style/rails/README.md
@@ -9,7 +9,7 @@ Rails
   suffixes.
 * Name initializers for their gem name.
 * Order ActiveRecord associations alphabetically by association type, then
-  attribute name.
+  attribute name. [Example][order-associations].
 * Order ActiveRecord validations alphabetically by attribute name.
 * Order ActiveRecord associations above ActiveRecord validations.
 * Order controller contents: filters, public methods, private methods.
@@ -20,6 +20,7 @@ Rails
 * Use the default `render 'partial'` syntax over `render partial: 'partial'`.
 * Use `link_to` for GET requests, and `button_to` for other HTTP verbs.
 
+[order-associations]: /style/rails/sample.rb#L2-L4
 [`app/views/application`]: http://asciicasts.com/episodes/269-template-inheritance
 
 Migrations

--- a/style/rails/sample.rb
+++ b/style/rails/sample.rb
@@ -1,0 +1,5 @@
+class SomeClass
+  belongs_to :tree
+  has_many :apples
+  has_many :watermelons
+end


### PR DESCRIPTION
There are two options how the current wording can be interpreted. This changes
the wording to favor the B option.

```rb
# A
has_many :apples
belongs_to :tree
has_many :watermelons

# B
belongs_to :tree
has_many :apples
has_many :watermelons
```