### PR TITLE
Use only one Haskell pragma per line

### DIFF
--- a/style/haskell/README.md
+++ b/style/haskell/README.md
@@ -5,13 +5,16 @@ Haskell
 
 * Break long expressions before operators or keywords.
 * Break long type signatures between arguments.
+* Use a blank line between pragma and module statements.
 * Order imports in three sections, separating each by a blank line:
   [standard libraries], third-party libraries, application modules.
   Within each section, alphabetize the imports and place qualified
   imports last.
+* Order pragma statements alphabetically.
 * Use comma-first style exports, records, and lists.
 * Use four-space indentation except the `where` keyword which is
   indented two spaces. [Example].
+* Use only one pragma statement per line.
 
 [standard libraries]: http://www.haskell.org/ghc/docs/latest/html/libraries/index.html
 [Example]: /style/haskell/sample.hs#L41

--- a/style/haskell/sample.hs
+++ b/style/haskell/sample.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
 module Haskell
     ( SomeType(..)
     , someFunction


### PR DESCRIPTION
* With too many on one line, it gets ugly and you'll be forced to wrap.
* You can be consistent if there's only one per line.