### PR TITLE
Prefer Sub-Routes over Maintaining State

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -298,6 +298,7 @@ Ember
 * Use `href="#"` for links that have an action.
 * Prefer dependency injection through Ember initializers over globals on window
   or namespaces.
+* Prefer sub-routes over maintaining state.
 
 Testing
 


### PR DESCRIPTION
http://emberjs.jsbin.com/puyude/2/edit

Canonical modal example:

Instead of maintaining a `showModal` flag in a controller or route that wraps
markup or a component, prefer introducing a new sub-route with its own model,
transitions, etc.

Benefits:

* updates the URL
 * deep linkable
 * back button closes the modal (for free)
* new route -> new model -> less scattered state
* simple controllers
* fewer actions to handle
* introduces the possibility to `link-to` to open a modal, instead of
 being forced to handle an `action`