### PR TITLE
Drop the branch prefix requirement

### DIFF
--- a/protocol/git/README.md
+++ b/protocol/git/README.md
@@ -24,8 +24,6 @@ Create a local feature branch based off master.
     git pull
     git checkout -b <branch-name>
 
-Prefix the branch name with your initials.
-
 Rebase frequently to incorporate upstream changes.
 
     git fetch origin

--- a/style/git/README.md
+++ b/style/git/README.md
@@ -2,7 +2,6 @@ Git
 ===
 
 * Avoid merge commits by using a [rebase workflow].
-* Prefix feature branch names with your initials.
 * Squash multiple trivial commits into a single commit.
 * Write a [good commit message].
 


### PR DESCRIPTION
It sometimes makes sense to prefix git branch names with your initial,
and it sometimes doesn't. Drop the requirement and let people do what
they deem right.