### PR TITLE
Ember-Data: Separate attributes and relations

### DIFF
--- a/style/ember/README.md
+++ b/style/ember/README.md
@@ -2,3 +2,11 @@ Ember
 =====
 
 * Don't put a space between the opening handlebars braces and the variable.
+
+Ember-Data
+----------
+
+* Visually separate relationships (`DS.{hasMany,belongsTo}`) from attributes
+  (`DS.attr`) with newlines. [Example][relationships]
+
+[relationships]: /style/ember/sample.js

--- a/style/ember/README.md
+++ b/style/ember/README.md
@@ -6,7 +6,7 @@ Ember
 Ember-Data
 ----------
 
-* Visually separate relationships (`DS.{hasMany,belongsTo}`) from attributes
-  (`DS.attr`) with newlines. [Example][relationships]
+* Visually separate relationships from attributes with newline.
+  [Example][relationships]
 
 [relationships]: /style/ember/sample.js

--- a/style/ember/sample.js
+++ b/style/ember/sample.js
@@ -1,0 +1,7 @@
+App.Post = DS.Model.extend({
+  author: DS.belongsTo("user"),
+  tags: DS.hasMany("tag"),
+
+  createdAt: DS.attr("date"),
+  title: DS.attr("string"),
+});


### PR DESCRIPTION
Ember-Data
----------

* Visually separate relationships (`DS.{hasMany,belongsTo}`) from attributes (`DS.attr`).


```javascript
export default DS.Model.extend({
  tags: DS.hasMany('tag'),

  title: DS.attr('string'),
});
```