### PR TITLE
Ember Testing: Prefer `findWithAssert` over `find`

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -299,6 +299,10 @@ Ember
 * Prefer dependency injection through Ember initializers over globals on window
   or namespaces.
 
+Testing
+
+* Prefer `findWithAssert` over `find`
+
 Angular
 -------
 


### PR DESCRIPTION
`findWithAssert` will raise an meaningful exception, whereas 
`find` is just a scoped version of `$()`, which will return an empty jQuery enumerable.