### PR TITLE
Ruby: Handle case for long method definitions

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -40,7 +40,8 @@ Formatting
 * Don't misspell.
 * Don't vertically align tokens on consecutive lines.
 * If you break up an argument list, keep the arguments on their own lines and
-  closing parenthesis on its own line.
+  closing parenthesis on its own line. [Example 1][multi-line arguments]
+  [Example 2][long method signature]
 * If you break up a hash, keep the elements on their own lines and closing curly
   brace on its own line.
 * Indent continued lines two spaces.
@@ -57,6 +58,9 @@ Formatting
 * Use [Unix-style line endings] (`\n`).
 * Use [uppercase for SQL key words and lowercase for SQL identifiers].
 
+
+[multi-line arguments]: /style/ruby/sample.rb#L69
+[long method signature]: /style/ruby/sample.rb#L16
 [dot guideline example]: /style/ruby/sample.rb#L11
 [uppercase for SQL key words and lowercase for SQL identifiers]: http://www.postgresql.org/docs/9.2/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 [Unix-style line endings]: http://unix.stackexchange.com/questions/23903/should-i-end-my-text-script-files-with-a-newline

--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -39,5 +39,5 @@ Ruby
 * Prefer `protected` over `private` for non-public `attr_reader`s, `attr_writer`s,
   and `attr_accessor`s.
 
-[trailing comma example]: /style/ruby/sample.rb#L49
-[required kwargs]: /style/ruby/sample.rb#L16
+[trailing comma example]: /style/ruby/sample.rb#L57
+[required kwargs]: /style/ruby/sample.rb#L24

--- a/style/ruby/sample.rb
+++ b/style/ruby/sample.rb
@@ -13,6 +13,14 @@ class SomeClass
       each_method_lives_on_its_own_line
   end
 
+  def method_with_long_signature(
+    the_first_arg:,
+    the_second_one:,
+    and_another_one:
+  )
+    # code here
+  end
+
   def method_with_required_keyword_arguments(one:, two:)
   end
 


### PR DESCRIPTION
Generally I think we want to prefer method definitions under 80 chars, but
there may be times where it "has" to be so I think we need how to handle that
documented.

This style was chosen to match how we handle long argument lists
[here](https://github.com/thoughtbot/guides/tree/master/style#formatting)