### PR TITLE
Prefer dependency injection through `Ember.inject`

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -299,7 +299,7 @@ Ember
 * Don't use jQuery outside of views and components.
 * Prefer to use predefined `Ember.computed.*` functions when possible.
 * Use `href="#"` for links that have an action.
-* Prefer dependency injection through Ember initializers over globals on window
+* Prefer dependency injection through `Ember.inject` over initializers, globals on window
   or namespaces.
 * Prefer sub-routes over maintaining state.
 

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -299,14 +299,16 @@ Ember
 * Don't use jQuery outside of views and components.
 * Prefer to use predefined `Ember.computed.*` functions when possible.
 * Use `href="#"` for links that have an action.
-* Prefer dependency injection through `Ember.inject` over initializers, globals on window
-  or namespaces.
+* Prefer dependency injection through `Ember.inject` over initializers, globals
+  on window, or namespaces. ([sample][inject])
 * Prefer sub-routes over maintaining state.
 
 Testing
 
 * Prefer `findWithAssert` over `find` when fetching an element you expect to
   exist
+
+[inject]: samples/ember.js#L1-L11
 
 Angular
 -------

--- a/best-practices/samples/ember.js
+++ b/best-practices/samples/ember.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+const { inject } = Ember;
+
+export default Ember.Controller({
+  applicationController: inject.controller('application'),
+  index: inject.controller(),
+
+  toastService: inject.service('toast'),
+  store: inject.service(),
+});


### PR DESCRIPTION
[Ember 1.10.0](ember) adds:

* `Ember.inject.service()`
* `Ember.inject.controller()`

[ember]: http://emberjs.com/blog/2015/02/07/ember-1-10-0-released.html#toc_injected-properties

[Ember-Data](ember-data) supports injecting the `store` as a service.

This makes injecting services via initializers a bad idea.

[ember-data]: http://emberjs.com/blog/2015/03/23/ember-data-1-0-beta-16-released.html#toc_store-as-a-service