### PR TITLE
Specify sass order for nested elements

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -28,8 +28,9 @@
 * Place `@extends` and `@includes` at the top of your declaration list.
 * Place media queries directly after the declaration list.
 * Place concatenated selectors second.
-* Place pseudo states and elements third.
-* Place nested selectors last.
+* Place pseudo-states and pseudo-elements third.
+* Place nested elements fourth.
+* Place nested classes fifth.
 
 ## Selectors
 

--- a/style/sass/sample.scss
+++ b/style/sass/sample.scss
@@ -25,6 +25,10 @@ section.application {
     content: ">";
   }
 
+  h1 {
+    attribute: value;
+  }
+
   .news {
     attribute: value;
     attribute: ($variable * 1.5) 2em;


### PR DESCRIPTION
Since nested element selectors can be so broad for what they touch, they should sit above any nested classes. 