### PR TITLE
Update Links in `README` and `protocol/README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,16 @@ Guides
 
 Guides for getting things done, programming well, and programming in style.
 
+* [Best Practices](/best-practices)
+* [Code Review](/code-review)
 * [Protocol](/protocol)
+  * [Communication](/protocol/communication)
   * [Git](/protocol/git)
-  * [Rails](/protocol/rails)
   * [iOS](/protocol/ios)
   * [Open Source](/protocol/open-source)
-* [Code Review](/code-review)
-* [Best Practices](/best-practices)
+  * [Product Review](/protocol/product-review)
+  * [Rails](/protocol/rails)
+* [Security](/security)
 * [Style](/style)
 
 High level guidelines:

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -5,6 +5,7 @@ Guides for getting things done.
 
 * [Communication](/protocol/communication)
 * [Git](/protocol/git)
-* [Rails](/protocol/rails)
 * [iOS](/protocol/ios)
 * [Open Source](/protocol/open-source)
+* [Product Review](/protocol/product-review)
+* [Rails](/protocol/rails)


### PR DESCRIPTION
In order to make it easier to quickly find information in the Guides
from the GitHub project page, this commit:

* Adds a missing link to `README` for the "Security" section
* Adds missing links to `README` and `protocol/README` for some
  "Protocol" sub-sections
* Sorts links alphabetically