### PR TITLE
Correct order of android:layout_width and android:layout_height

### DIFF
--- a/style/android/android_layout.xml
+++ b/style/android/android_layout.xml
@@ -6,8 +6,8 @@
   >
   <TextView
     android:id="@+id/system_name"
-    android:layout_height="48sp"
     android:layout_width="match_parent"
+    android:layout_height="48sp"
     android:background="@color/brand_red"
     android:gravity="center_vertical"
     android:layout_alignBottom="@id/system_image"


### PR DESCRIPTION
Hey guys, those two were reversed in comparison to the order from https://github.com/thoughtbot/guides/blob/master/style/android/README.md.