### PR TITLE
Prefer method invocation over instance variables

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -42,6 +42,7 @@ Ruby
 * Prefer `protected` over `private` for non-public `attr_reader`s, `attr_writer`s,
   and `attr_accessor`s.
 * Order class methods above instance methods.
+* Prefer method invocation over instance variables.
 
 [trailing comma example]: /style/ruby/sample.rb#L49
 [required kwargs]: /style/ruby/sample.rb#L16

--- a/style/ruby/sample.rb
+++ b/style/ruby/sample.rb
@@ -77,7 +77,7 @@ class SomeClass
   end
 
   def method_that_uses_factory
-    user = @user_factory.new
+    user = user_factory.new
     user.ensure_authenticated!
   end
 
@@ -87,7 +87,7 @@ class SomeClass
 
   protected
 
-  attr_reader :foo
+  attr_reader :foo, :user_factory
   attr_accessor :bar
   attr_writer :baz
 


### PR DESCRIPTION
Referring to instance variables in various methods within a class
violates the single level of abstraction principle; it applies a
specificity that methods using this information need no context of.

By preferring method invocation over instance variables, it provides the
developer the ability to refer to a concept which can be defined by a
method via direct definition or via `attr`, `attr_reader`, or `attr_accessor`.