### PR TITLE
Avoid `class A::B` definitions

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -13,6 +13,8 @@ Ruby
 * Avoid bang (!) method names. Prefer descriptive names.
 * Don't use `self` explicitly anywhere except class methods (`def self.method`)
   and assignments (`self.attribute =`).
+* Prefer nested class and module definitions over the shorthand version
+  [Example][class definition example]
 * Prefer `detect` over `find`.
 * Prefer `select` over `find_all`.
 * Prefer `map` over `collect`.
@@ -42,3 +44,4 @@ Ruby
 
 [trailing comma example]: /style/ruby/sample.rb#L57
 [required kwargs]: /style/ruby/sample.rb#L24
+[class definition example]: /style/ruby/sample.rb#L121

--- a/style/ruby/sample.rb
+++ b/style/ruby/sample.rb
@@ -117,3 +117,8 @@ class SomeClass
     part_one? && part_two?
   end
 end
+
+module A
+  class B
+  end
+end


### PR DESCRIPTION
`ctags` is an extremely useful tool for navigating quickly to a class,
module, or method definition. Sadly it has a few limitations, one of
them is how namespaced classes/modules are defined.

If we define a class `B` like so: `class A::B; end`, `B` will never be
found nor indexed by `ctags`.

By defining classes like:

```ruby
module A
  class B
  # body omitted
  end
end
```

We can use `ctags` to navigate to `B` (and `A` for that matter aswell`)