### PR TITLE
Remove HTML tag from SCSS sample

### DIFF
--- a/style/sass/sample.scss
+++ b/style/sass/sample.scss
@@ -1,7 +1,6 @@
 @import "bourbon";
 
-section.application {
-  @extend %extend;
+.featured-article {
   @include mixin;
   attribute: value;
 


### PR DESCRIPTION
Because 

>Avoid using HTML tags on classes for generic markup `<div>`, `<span>`: `.widgets not div.widgets`.
>Avoid using HTML tags on classes with specific class names like .featured-articles.

https://github.com/thoughtbot/guides/tree/master/style/sass

Though it could be argued that `.application` is not the BEST class name, especially if it was a `<section>`...