### PR TITLE
Prefer single quotes for javascript

### DIFF
--- a/style/ember/sample.js
+++ b/style/ember/sample.js
@@ -1,18 +1,18 @@
 App.Post = DS.Model.extend({
-  author: DS.belongsTo("user"),
-  tags: DS.hasMany("tag"),
+  author: DS.belongsTo('user'),
+  tags: DS.hasMany('tag'),
 
-  createdAt: DS.attr("date"),
-  title: DS.attr("string"),
+  createdAt: DS.attr('date'),
+  title: DS.attr('string'),
 });
 
-test("checks the box", function() {
-  visit("/");
-  click(".check-box");
+test('checks the box', function() {
+  visit('/');
+  click('.check-box');
 
   andThen(function() {
-    const checkBox = find(".check-box");
+    const checkBox = find('.check-box');
 
-    ok(checkBox.prop("checked"), "box is checked");
+    ok(checkBox.prop('checked'), 'box is checked');
   });
 });

--- a/style/javascript/README.md
+++ b/style/javascript/README.md
@@ -9,7 +9,7 @@ JavaScript
 * Prefer [arrow functions] `=>`, over the `function` keyword except when
   defining classes or methods.
 * Use semicolons at the end of each statement.
-* Prefer double quotes.
+* Prefer single quotes.
 * Use `PascalCase` for classes, `lowerCamelCase` for variables and functions,
   `SCREAMING_SNAKE_CASE` for constants, `_singleLeadingUnderscore` for private
   variables and functions.


### PR DESCRIPTION
See related PR in ember: https://github.com/emberjs/ember.js/pull/11142

ember-cli generates files with single quotes, so preferring single quotes for ember projects makes it easier to work with the de-facto toolchain, i.e. ember-cli.

Our javascript guide prefers double quotes, and I'm not sure how we want to deal with that. Maybe for now, we can simply recommend single quotes for ember projects, and double quotes for non-ember? Thoughts welcome https://github.com/thoughtbot/guides/tree/master/style/javascript