### PR TITLE
Prefer not using prototype extensions on functions

### DIFF
--- a/style/ember/README.md
+++ b/style/ember/README.md
@@ -2,8 +2,8 @@ Ember
 =====
 
 * Don't put a space between the opening handlebars braces and the variable.
-* Prefer not using prototype extensions for `computed` or `observes`
-  ([sample][prototype extensions])
+* Use `Ember.computed`, `Ember.observes`, and `Ember.on` instead of the function
+  prototype extensions ([sample][prototype extensions])
 
 Ember-Data
 ----------

--- a/style/ember/README.md
+++ b/style/ember/README.md
@@ -2,6 +2,8 @@ Ember
 =====
 
 * Don't put a space between the opening handlebars braces and the variable.
+* Prefer not using prototype extensions for `computed` or `observes`
+  ([sample][prototype extensions])
 
 Ember-Data
 ----------
@@ -20,3 +22,4 @@ Testing
 
 [helpers]: sample.js#L10-L11
 [assertions]: sample.js#L13-L17
+[prototype extensions]: sample.js#L23-L25

--- a/style/ember/sample.js
+++ b/style/ember/sample.js
@@ -16,3 +16,11 @@ test("checks the box", function() {
     ok(checkBox.prop("checked"), "box is checked");
   });
 });
+
+Ember.Object.extend({
+  name: 'something',
+
+  title: Ember.computed('name', function() {
+    return this.get('name').capitalize();
+  }),
+});


### PR DESCRIPTION
Why:

* The non-prototype extension versions of `.property` and `.observes`
are easier to grok.
* Prototype extensions can be disabled. If you are an addon author this
means you have to write you addon without using prototype extensions.
* In my opinion, having a clear separation between features of Ember vs
native in JavaScript leads to less confusion.

This PR:

* Adds the guideline to `style/ember/README.md`
* Adds an example to `style/ember/sample.js`