### PR TITLE
Local Ember/DS functions

### DIFF
--- a/style/ember/README.md
+++ b/style/ember/README.md
@@ -3,6 +3,10 @@ Ember
 
 * Don't put a space between the opening handlebars braces and the variable.
 * Prefer components over partials.
+* Alias local variables to functions from `Ember` and `DS`
+([sample][local-Ember-DS])
+
+[local-Ember-DS]: sample.js#L23-L24
 
 Ember-Data
 ----------

--- a/style/ember/sample.js
+++ b/style/ember/sample.js
@@ -16,3 +16,14 @@ test('checks the box', function() {
     ok(checkBox.prop('checked'), 'box is checked');
   });
 });
+
+import Ember from 'ember';
+import DS from 'ember-data';
+
+const { computed } = Ember;
+const { attr, hasMany, belongsTo } = DS;
+
+export default DS.Model.extend({
+  name: attr('string'),
+  ...
+});


### PR DESCRIPTION
Why:

* Ember and Ember-Data will move to JavaScript modules allowing us to
only import functions we actually use.

This PR:

* Proposes creating local constants for functions on `Ember` and `DS`
* This means when these libraries are converted to modules, updating the
code is as simple as converting:
```js
const { computed } = Ember;
```
to:
```js
import { computed } from 'ember';
```