### PR TITLE
Ember: Prefer `ember-fetch` over `ic-ajax`

### DIFF
--- a/style/ember/README.md
+++ b/style/ember/README.md
@@ -5,8 +5,11 @@ Ember
 * Prefer components over partials.
 * Alias local variables to functions from `Ember` and `DS`
 ([sample][local-Ember-DS])
+* Prefer [ember-fetch] over ic-ajax. ([sample][ember-fetch-sample])
 
 [local-Ember-DS]: sample.js#L23-L24
+[ember-fetch]: https://github.com/stefanpenner/ember-fetch
+[ember-fetch-sample]: sample.js#L20-L29
 
 Ember-Data
 ----------

--- a/style/ember/sample.js
+++ b/style/ember/sample.js
@@ -27,3 +27,14 @@ export default DS.Model.extend({
   name: attr('string'),
   ...
 });
+
+import fetch from 'fetch';
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model() {
+    return fetch('/my-cool-end-point.json').then(function(response) {
+      return response.json();
+    });
+  }
+});


### PR DESCRIPTION
Stefan is looking for people to try this out and give feedback.
We have enough Ember projects that we could contribute
good information to this RFC and the spec.

There isn't much risk to establishing this preference
because it's being polyfilled so it will work wherever.

The gain is that we will be able to
provide valuable feedback to the ember community.
Assuming this eventually get's merged we will also be ahead
of the curve and not need to update existing apps
to accommodate it.

> What is ember-fetch?
>
> * a wrapper around: https://github.com/github/fetch
> * which is a partial polyfil for  https://fetch.spec.whatwg.org/
> * more info: https://github.com/stefanpenner/ember-fetch
> * never falls back to native (so always works the same, and works with pretender)
>
> Why is this discussion happening now and not earlier?
>
> * ember 2 no longer supports IE8, and github/fetch is IE9+
> * fetch is a spec primitive of the DOM, it stands to reason we should prefer that over $.ajax
> * maybe we can catch issues to help adapt/improve/add to the spec
> * $.ajax is crazy quirky
> * uploads have progress in the request object (unsure if the polifill does this or not actually, need to verify)
>
> Cons:
>
> * its not $.ajax which, although not a spec thing, is basically a primitive many devs are used to
> * features like `$.ajaxPrefilter` are not obviously a thing in `fetch` (maybe some other approach ?)
> * .... ?
>
>
> Noop:
>
> * still no formal cancelation
>
> RFC: https://github.com/ember-cli/rfcs/issues/19