### PR TITLE
Adjust BAD example to use `subject`

### DIFF
--- a/style/testing/avoid_let_spec.rb
+++ b/style/testing/avoid_let_spec.rb
@@ -1,4 +1,4 @@
-# BAD
+# Not recommended
 describe ReportPolicy do
   let(:report_id) { 2 }
   let(:report_policy) do
@@ -12,22 +12,18 @@ describe ReportPolicy do
     subject { report_policy.allowed? }
     
     context "when user has access to report" do
-      it "returns true" do
-        expect(subject).to eql(true)
-      end
+      it { should be true }
     end
 
     context "when user does not have access to report" do
       let(:report_id) { 3 }
       
-      it "returns false" do
-        expect(subject).to eql(false)
-      end
+      it { should be false }
     end
   end
 end
 
-# GOOD
+# Recommended
 describe ReportPolicy do
   describe "#allowed?" do
     context "when user has access to report" do

--- a/style/testing/avoid_let_spec.rb
+++ b/style/testing/avoid_let_spec.rb
@@ -1,23 +1,27 @@
 # BAD
 describe ReportPolicy do
-  let(:user) { User.new(report_ids: [1, 2]) }
-  let(:report) { Report.new(id: 2) }
+  let(:report_id) { 2 }
+  let(:report_policy) do
+    ReportPolicy.new(
+      User.new(report_ids: [1,2]),
+      Report.new(id: report_id)
+    )
+  end
 
   describe "#allowed?" do
+    subject { report_policy.allowed? }
+    
     context "when user has access to report" do
       it "returns true" do
-        policy = ReportPolicy.new(user, report)
-
-        expect(policy).to be_allowed
+        expect(subject).to eql(true)
       end
     end
 
     context "when user does not have access to report" do
+      let(:report_id) { 3 }
+      
       it "returns false" do
-        report.id = 3
-        policy = ReportPolicy.new(user, report)
-
-        expect(policy).not_to be_allowed
+        expect(subject).to eql(false)
       end
     end
   end


### PR DESCRIPTION
@gylaz

As per https://github.com/thoughtbot/guides/commit/ae1c6bb3a52ac5ea36cb16060e864f4c957effc7#commitcomment-12043014

Adjusting the "BAD" example of `let` vs `def` to utilize `subject`, `let`, and `context` since that at least shows the (perhaps flawed) intention of the "BAD" way to properly contrast the more complex structure against the simpler, more straightforward `def` form.