### PR TITLE
Drop support for IE9

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -218,7 +218,7 @@ Sass
 Browsers
 --------
 
-* Don't support versions of Internet Explorer before IE9.
+* Don't support versions of Internet Explorer before IE10.
 
 Objective-C
 -----------


### PR DESCRIPTION
The playbook was updated a few weeks ago to indicate that we no longer
support IE9 by default. There may be business cases where this is deemed
necessary, but our best practices should align with the playbook.