### PR TITLE
Avoid using non-standard DNS entries

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -220,6 +220,11 @@ Browsers
 
 * Don't support versions of Internet Explorer before IE9.
 
+DNS
+---
+
+* Avoid using non-standard DNS entries (i.e. ALIAS, ANAME).
+
 Objective-C
 -----------
 


### PR DESCRIPTION
We have frequently configured our sites and client sites to redirect the
`www` subdomain to the zone apex. For example, `www.thoughtbot.com`
redirects to `thoughtbot.com`. This works fine until you decide to put
the site behind a CDN.  Using a CDN like Fastly requires that you CNAME
your host to their servers. Per DNS spec, you cannot have a CNAME at
your zone apex.

We get around this by using DNSimple, which has an `ALIAS` record that
effectively simulates a CNAME at the apex. This isn't standard though,
and most providers do not offer it. Providers that do, often offer it as
an `ANAME` instead -- also non-standard. By relying on one of these
record types, we are locking ourselves in to these providers and more
importantly making it more difficult to be fault tolerant.

DNSimple went down hard last year and took all of our sites and
customers with them. Had we been using standard DNS servers it would
have been a best practice to have a backup provider listed as one of our
name servers. Backup providers can sync your DNS records from your
primary provider via zone transfer (`AXFR`). But the proprietary nature
of DNSimple's ALIAS was at least in-part responsible for this not being
possible with DNSimple. Even if we had access to our full zone record,
uploading to another provider would have meant temporarily compromising
the ALIAS feature.

DNSimple has since worked out secondary DNS offerings provided by a
limited number of providers. If those providers don't support `ALIAS`
then DNSimple pushes the IP that `ALIAS` resolves to as an `A` record.
So you're again throwing out the `ALIAS` functionality.

Most of this should "just work" now that they've put some effort behind
it, but it's still a lot of magic for something that can just be avoided
by forgoing the vanity of an apex domain. Yes, it looks prettier, but I
don't think it's worth all of this hullabaloo. I've learned to stop
worrying and love my www.

This PR comes out of a discussion on thoughtbot/suspenders/565.