### PR TITLE
Prevent spacing in objects for JavaScript

### DIFF
--- a/style/javascript/README.md
+++ b/style/javascript/README.md
@@ -19,6 +19,8 @@ JavaScript
 * Use `const` for declaring variables that will never be re-assigned, and `let`
   otherwise.
 * Avoid `var` to declare variables.
+* Do not include a space after the opening brace of an object or before the closing
+  brace.
 
 [template strings]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings
 [arrow functions]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions

--- a/style/javascript/sample.js
+++ b/style/javascript/sample.js
@@ -1,4 +1,4 @@
-object = { spacing: true }
+object = {spacing: false}
 
 class Cat {
   canBark() {


### PR DESCRIPTION
ESlint recommends this style by default: http://eslint.org/docs/rules/object-curly-spacing

Let the discussion begin!