### PR TITLE
Do not include spaces inside braces

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -42,7 +42,7 @@ Ruby
 * Prefer `protected` over `private` for non-public `attr_reader`s, `attr_writer`s,
   and `attr_accessor`s.
 * Order class methods above instance methods.
-* Do not include a space after the opening brace of an object or before the closing
+* Do not include a space after the opening brace of a hash or before the closing
   brace.
 
 [trailing comma example]: /style/ruby/sample.rb#L57

--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -42,6 +42,8 @@ Ruby
 * Prefer `protected` over `private` for non-public `attr_reader`s, `attr_writer`s,
   and `attr_accessor`s.
 * Order class methods above instance methods.
+* Do not include a space after the opening brace of an object or before the closing
+  brace.
 
 [trailing comma example]: /style/ruby/sample.rb#L57
 [required kwargs]: /style/ruby/sample.rb#L24

--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -42,7 +42,7 @@ Ruby
 * Prefer `protected` over `private` for non-public `attr_reader`s, `attr_writer`s,
   and `attr_accessor`s.
 * Order class methods above instance methods.
-* Do not include a space after the opening brace of a hash or before the closing
+* Do not include a space after an opening brace or before a closing
   brace.
 
 [trailing comma example]: /style/ruby/sample.rb#L57

--- a/style/ruby/sample.rb
+++ b/style/ruby/sample.rb
@@ -40,7 +40,7 @@ class SomeClass
   end
 
   def method_with_oneline_combined_methods_block
-    items.map { |item| "#{item.one} #{item.two}" }
+    items.map {|item| "#{item.one} #{item.two}"}
   end
 
   def method_that_returns_an_array
@@ -48,7 +48,7 @@ class SomeClass
   end
 
   def method_that_returns_a_hash
-    { :key => "value" }
+    {:key => "value"}
   end
 
   def method_with_large_hash


### PR DESCRIPTION
This is related to this PR: https://github.com/thoughtbot/guides/pull/348

We don't have a guide for this currently and I think in this case it may be best to have a rule that is the same for most languages (specifically JavaScript and Ruby), since there is no clear reason.

There is not a huge reason for either side of this debate. I think that the extra spacing doesn't provide much benefit. The other benefit to omitting the spacing is that both Python and Elixir require you to omit the braces. This is minor but I think when it comes to a decision that is purely based on preference, minor things make an impact.
