### PR TITLE
Prefer `each_with_object` over `reduce`

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -19,6 +19,8 @@ Ruby
 * Prefer `select` over `find_all`.
 * Prefer `map` over `collect`.
 * Prefer `reduce` over `inject`.
+* Prefer `each_with_object` over `reduce` for building hashes from arrays.
+  [Example][each_with_object example]
 * Prefer double quotes for strings.
 * Prefer `&&` and `||` over `and` and `or`.
 * Prefer `!` over `not`.
@@ -45,4 +47,5 @@ Ruby
 
 [trailing comma example]: /style/ruby/sample.rb#L57
 [required kwargs]: /style/ruby/sample.rb#L24
-[class definition example]: /style/ruby/sample.rb#L121
+[class definition example]: /style/ruby/sample.rb#L127
+[each_with_object example]: /style/ruby/sample.rb#L104

--- a/style/ruby/sample.rb
+++ b/style/ruby/sample.rb
@@ -101,6 +101,12 @@ class SomeClass
     user.ensure_authenticated!
   end
 
+  def method_which_uses_each_with_object
+    items.each_with_object({}) do |item, hash|
+      hash[item] = true
+    end
+  end
+
   def self.class_method
     method_body
   end


### PR DESCRIPTION
There are a few possible ways
to build a hash from an array of items,
most commonly by `reduce` or `each_with_object`

`each_with_object` offers a few advantages over `reduce`:

  * The order of arguments is described by the method name
  * The order of arguments is familiar
    because of `each_with_index`
  * The block does not need to return the hash

Thus we prefer:

```ruby
items.each_with_object({}) do |item, hash|
  hash[item] = true
end
```

to:

```ruby
items.reduce({}) do |hash, item|
  hash[item] = true
  hash
end
```