### PR TITLE
Recommend new-style Rails validations

### DIFF
--- a/style/rails/README.md
+++ b/style/rails/README.md
@@ -19,8 +19,11 @@ Rails
 * Use `def self.method`, not the `scope :method` DSL.
 * Use the default `render 'partial'` syntax over `render partial: 'partial'`.
 * Use `link_to` for GET requests, and `button_to` for other HTTP verbs.
+* Use new-style `validates :name, presence: true` validations, and put all
+  validations for a given column together. [Example][validations].
 
 [order-associations]: /style/rails/sample.rb#L2-L4
+[validations]: /style/rails/sample.rb#L6
 [`app/views/application`]: http://asciicasts.com/episodes/269-template-inheritance
 
 Migrations

--- a/style/rails/sample.rb
+++ b/style/rails/sample.rb
@@ -2,4 +2,6 @@ class SomeClass
   belongs_to :tree
   has_many :apples
   has_many :watermelons
+
+  validates :name, presence: true, uniqueness: true
 end


### PR DESCRIPTION
Avoid:

validates :name, presence: true
validates :name, uniqueness: true

or:

validates_presence_of :name
validates_uniqueness_of :name

Using new-style validations like in the recommended example forces all of the
validations for a given column to be in one place, making it easy to scan a
model's validations.