### PR TITLE
Order models attributes then relationships

### DIFF
--- a/style/ember/README.md
+++ b/style/ember/README.md
@@ -14,8 +14,8 @@ Ember
 Ember-Data
 ----------
 
-* Visually separate relationships from attributes with a newline.
-  [Example][relationships]
+* Organize your models with attributes then relationships, separated with a
+  newline [Example][relationships]
 
 [relationships]: sample.js#L1-L7
 

--- a/style/ember/sample.js
+++ b/style/ember/sample.js
@@ -1,9 +1,9 @@
 App.Post = DS.Model.extend({
-  author: DS.belongsTo('user'),
-  tags: DS.hasMany('tag'),
-
   createdAt: DS.attr('date'),
   title: DS.attr('string'),
+
+  author: DS.belongsTo('user'),
+  tags: DS.hasMany('tag'),
 });
 
 test('checks the box', function() {


### PR DESCRIPTION
Why:

* Ember data gives examples with this ordering:
https://github.com/emberjs/data#defining-your-models
* Open source ember projects appear to favor this ordering.

This PR:

* Changes the order in our sample model to attributes then
relationships.
* Clarify our style on ordering ember-data models