### PR TITLE
Prefer ember-ajax over ic-ajax

### DIFF
--- a/style/ember/README.md
+++ b/style/ember/README.md
@@ -5,11 +5,11 @@ Ember
 * Prefer components over partials.
 * Alias local variables to functions from `Ember` and `DS`
 ([sample][local-Ember-DS])
-* Prefer [ember-fetch] over ic-ajax. ([sample][ember-fetch-sample])
+* Prefer [ember-ajax] over ic-ajax. ([sample][ember-ajax-sample])
 
 [local-Ember-DS]: sample.js#L23-L24
-[ember-fetch]: https://github.com/stefanpenner/ember-fetch
-[ember-fetch-sample]: sample.js#L20-L29
+[ember-ajax]: https://github.com/ember-cli/ember-ajax
+[ember-ajax-sample]: sample.js#L31-L38
 
 Ember-Data
 ----------

--- a/style/ember/sample.js
+++ b/style/ember/sample.js
@@ -28,13 +28,11 @@ export default DS.Model.extend({
   ...
 });
 
-import fetch from 'fetch';
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  ajax: Ember.inject.service(),
   model() {
-    return fetch('/my-cool-end-point.json').then(function(response) {
-      return response.json();
-    });
+    return this.get('ajax').request('/posts');
   }
 });


### PR DESCRIPTION
Why:

* The ember-fetch RFC was an experiement that [failed].
* This is now the recommended approach from the ember-cli team.

[failed]: https://github.com/ember-cli/rfcs/issues/19#issuecomment-137952616

This change addresses the need by:

* Updating the copy and sample to prefer ember-ajax over ic-ajax