### PR TITLE
Update SCSS sample

### DIFF
--- a/style/sass/sample.scss
+++ b/style/sass/sample.scss
@@ -1,53 +1,35 @@
-@import "bourbon";
+@import "partial-name";
 
-.featured-article {
-  @include mixin;
-  attribute: value;
+.class-one {
+  background-color: $color-variable;
+  border: 0;
 
-  @include media(value) {
-    attribute: value;
-  }
-
-  &.additional-selector {
-    attribute: value;
+  @media (min-width: $screen-variable) {
+    margin: ($spacing-variable * 2) 1rem;
   }
 
   &:hover {
-    attribute: value;
+    box-shadow: 0 0 2px 1px rgba($color-variable, 0.2);
   }
 
   &::before {
-    content: "<";
+    content: "hello";
   }
+}
 
-  &::after {
-    content: ">";
-  }
+.class-two {
+  @extend %placeholder;
+  @include mixin;
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
 
-  h1 {
-    attribute: value;
-  }
+  a {
+    text-decoration: none;
 
-  .news {
-    attribute: value;
-    attribute: ($variable * 1.5) 2em;
-
-    article {
-      @extend media(value) {
-        attribute: value;
-      }
-
-      p {
-        attribute: value;
-      }
-    }
-  }
-
-  .sidebar {
-    attribute: value;
-
-    h2 {
-      attribute: value;
+    &:focus,
+    &:hover {
+      text-decoration: underline;
     }
   }
 }


### PR DESCRIPTION
I don’t think our current SCSS sample provides the full picture, and might even encourage a bit of bad behavior. So I updated to:

- Change the `@import` to indicate that partial names should use hyphens
- Remove nesting where it was unnecessary, which gave the wrong
  impression
- Use more class selectors and less element selectors
- Use actual CSS properties and values so that it renders with better code
  highlighting on GitHub
- Remove reference to Neat’s `media` helper, because Neat is not always used and
  this should focus more on plain SCSS style
- Show use of zero values to indicate that they should not have a unit
- Show that `@extend` should come before `@include`
- Show the multiple selectors should go on their own line
- Use `background-color` to indicate that we prefer it over just `background`