### PR TITLE
Avoid writing vendor prefixes

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -205,6 +205,10 @@ CSS
 ---
 
 * Use Sass.
+* Use [Autoprefixer][autoprefixer] to generate vendor prefixes based on the
+  project-specific browser support that is needed.
+
+[autoprefixer]: https://github.com/postcss/autoprefixer
 
 Sass
 ----


### PR DESCRIPTION
I’d like to encourage use of Autoprefixer. It might be a bit wordy.

Thoughts?