### PR TITLE
Soften our stance on IE support

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -222,7 +222,7 @@ Sass
 Browsers
 --------
 
-* Don't support versions of Internet Explorer before IE10.
+* Avoid supporting versions of Internet Explorer before IE10.
 
 Objective-C
 -----------


### PR DESCRIPTION
According to the [README](https://github.com/thoughtbot/guides#guides), we should say “Don’t” when “…there's never a good reason”.

So should we not _ever_ work on a project that needs IE9 support?

I think “never” is a really strong word, especially in this case. Browser support depends on the project and the audience it has. We should analyze needs and openly discuss with the team, defaulting to IE10+ whenever we can.

cc: @thoughtbot/design 