### PR TITLE
Adjust line-wrapping rules for Rails macros

### DIFF
--- a/style/rails/README.md
+++ b/style/rails/README.md
@@ -19,8 +19,15 @@ Rails
 * Use `def self.method`, not the `scope :method` DSL.
 * Use the default `render 'partial'` syntax over `render partial: 'partial'`.
 * Use `link_to` for GET requests, and `button_to` for other HTTP verbs.
+* If you break up an argument list for a macro,
+  keep the first argument on the same line as the macro,
+  and break the following arguments onto their own lines.
+  [Example 1][multi-line macro 1]
+  [Example 2][multi-line macro 2]
 
 [order-associations]: /style/rails/sample.rb#L2-L4
+[multi-line macro 1]: /style/rails/sample.rb#L4
+[multi-line macro 2]: /style/rails/sample.rb#L10
 [`app/views/application`]: http://asciicasts.com/episodes/269-template-inheritance
 
 Migrations

--- a/style/rails/sample.rb
+++ b/style/rails/sample.rb
@@ -1,5 +1,13 @@
 class SomeClass
   belongs_to :tree
   has_many :apples
+  has_many :pumpkins,
+    class_name: "Gourd",
+    foreign_key: :gourd_id
   has_many :watermelons
+
+  validates :name, presence: true
+  validates :title,
+    uniqueness: { scope: :tree_id, case_sensitive: false },
+    allow_nil: true
 end


### PR DESCRIPTION
See slack conversation:
https://thoughtbot.slack.com/archives/ruby/p1444250120000353

This adds a new rule for Rails that overrides the default line break
rule in the main README.

This aims to make it easier to scan lists of macros and find the one
you're looking for without having to look at the following line if it's
wrapped.

See the new examples.