### PR TITLE
Remove argument list style guide

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -39,9 +39,6 @@ Formatting
 * Don't include spaces after `(`, `[` or before `]`, `)`.
 * Don't misspell.
 * Don't vertically align tokens on consecutive lines.
-* If you break up an argument list, keep the arguments on their own lines and
-  closing parenthesis on its own line. [Example 1][multi-line arguments]
-  [Example 2][long method signature]
 * If you break up a hash, keep the elements on their own lines and closing curly
   brace on its own line.
 * Indent continued lines two spaces.
@@ -59,8 +56,6 @@ Formatting
 * Use [uppercase for SQL key words and lowercase for SQL identifiers].
 
 
-[multi-line arguments]: /style/ruby/sample.rb#L69
-[long method signature]: /style/ruby/sample.rb#L16
 [dot guideline example]: /style/ruby/sample.rb#L11
 [uppercase for SQL key words and lowercase for SQL identifiers]: http://www.postgresql.org/docs/9.2/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 [newline explanation]: http://unix.stackexchange.com/questions/23903/should-i-end-my-text-script-files-with-a-newline

--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -43,6 +43,6 @@ Ruby
   and `attr_accessor`s.
 * Order class methods above instance methods.
 
-[trailing comma example]: /style/ruby/sample.rb#L57
-[required kwargs]: /style/ruby/sample.rb#L24
-[class definition example]: /style/ruby/sample.rb#L121
+[trailing comma example]: /style/ruby/sample.rb#L49
+[required kwargs]: /style/ruby/sample.rb#L16
+[class definition example]: /style/ruby/sample.rb#L101

--- a/style/ruby/sample.rb
+++ b/style/ruby/sample.rb
@@ -13,14 +13,6 @@ class SomeClass
       each_method_lives_on_its_own_line
   end
 
-  def method_with_long_signature(
-    the_first_arg:,
-    the_second_one:,
-    and_another_one:
-  )
-    # code here
-  end
-
   def method_with_required_keyword_arguments(one:, two:)
   end
 
@@ -64,18 +56,6 @@ class SomeClass
       :two,
       :three,
     ]
-  end
-
-  def invoke_method_with_arguments_on_multiple_lines
-    some_method(
-      i_am_a_long_variable_name_that_will_never_fit_on_one_line_with_others,
-      two,
-      three
-    )
-
-    # Bad:
-    some_method(one,
-                two)
   end
 
   def method_which_uses_infix_operators


### PR DESCRIPTION
This guideline has proven to be the most unintuitive one, most often
broken and complained about in Slack and real life. It's the one that we
only get right after Hound complains other times. In short, it's not
natural.

Removing this guideline allows us to put the art back into formatting,
giving us the freedom to align arguments in the style that is most
readable and expressive.