### PR TITLE
Prefer `--force-with-lease` over `--force`

### DIFF
--- a/protocol/git/README.md
+++ b/protocol/git/README.md
@@ -98,7 +98,7 @@ Force push your branch. This allows GitHub to automatically close your pull
 request and mark it as merged when your commit(s) are pushed to master. It also
  makes it possible to [find the pull request] that brought in your changes.
 
-    git push --force origin <branch-name>
+    git push --force-with-lease origin <branch-name>
 
 View a list of new commits. View changed files. Merge branch into master.
 


### PR DESCRIPTION
Using `--force-with-lease` allows one to force push without the risk of
unintentionally overwriting someone else's work.

The git-push(1) man page states:

> Usually, "git push" refuses to update a remote ref that is not an
> ancestor of the local ref used to overwrite it.
>
> This option overrides this restriction if the current value of the
> remote ref is the expected value. "git push" fails otherwise.
>
> --force-with-lease alone, without specifying the details, will protect
> all remote refs that are going to be updated by requiring their
> current value to be the same as the remote-tracking branch we have for
> them.