### PR TITLE
Add best practices for building Ruby JSON APIs

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -335,8 +335,11 @@ Ruby JSON APIs
 
 * Follow Heroku's [HTTP API Design Guide]
 * Use a fast JSON parser, e.g. [`oj`][oj]
-* Write [request specs] for your API endpoints
+* Write integration tests for your API endpoints. When the primary consumer of
+  your API is an in-app JavaScript client, write [feature specs]. Otherwise
+  write [request specs].
 
 [HTTP API Design Guide]: https://github.com/interagent/http-api-design
 [oj]: https://github.com/ohler55/oj
+[feature specs]: https://www.relishapp.com/rspec/rspec-rails/docs/feature-specs/feature-spec
 [request specs]: https://www.relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -271,7 +271,7 @@ Shell
 * Use the `local` keyword with function-scoped variables.
 * Identify common problems with [shellcheck][].
 
-oshebang]: http://en.wikipedia.org/wiki/Shebang_(Unix)
+[shebang]: http://en.wikipedia.org/wiki/Shebang_(Unix)
 [parsingls]: http://mywiki.wooledge.org/ParsingLs
 [bashisms]: http://mywiki.wooledge.org/Bashism
 [shellcheck]: http://www.shellcheck.net/

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -329,3 +329,14 @@ Angular
 [annotations]: http://robots.thoughtbot.com/avoid-angularjs-dependency-annotation-with-rails
 [ngannotate]: https://github.com/kikonen/ngannotate-rails
 [angular-translate]: https://github.com/angular-translate/angular-translate/wiki/Getting-Started#using-translate-directive
+
+Ruby JSON APIs
+--------------
+
+* Follow Heroku's [HTTP API Design Guide]
+* Use [`oj`][oj] for parsing JSON
+* Write [request specs] for your API endpoints
+
+[HTTP API Design Guide]: https://github.com/interagent/http-api-design
+[oj]: https://github.com/ohler55/oj
+[request specs]: https://www.relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -336,8 +336,8 @@ Ruby JSON APIs
 * Follow Heroku's [HTTP API Design Guide]
 * Use a fast JSON parser, e.g. [`oj`][oj]
 * Write integration tests for your API endpoints. When the primary consumer of
-  your API is an in-app JavaScript client, write [feature specs]. Otherwise
-  write [request specs].
+  the API is a JavaScript client maintained within the same code base as the
+  provider of the API, write [feature specs]. Otherwise write [request specs].
 
 [HTTP API Design Guide]: https://github.com/interagent/http-api-design
 [oj]: https://github.com/ohler55/oj

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -271,7 +271,7 @@ Shell
 * Use the `local` keyword with function-scoped variables.
 * Identify common problems with [shellcheck][].
 
-[shebang]: http://en.wikipedia.org/wiki/Shebang_(Unix)
+oshebang]: http://en.wikipedia.org/wiki/Shebang_(Unix)
 [parsingls]: http://mywiki.wooledge.org/ParsingLs
 [bashisms]: http://mywiki.wooledge.org/Bashism
 [shellcheck]: http://www.shellcheck.net/
@@ -333,7 +333,8 @@ Angular
 Ruby JSON APIs
 --------------
 
-* Follow Heroku's [HTTP API Design Guide]
+* Review the recommended practices outlined in Heroku's [HTTP API Design Guide]
+  before designing a new API.
 * Use a fast JSON parser, e.g. [`oj`][oj]
 * Write integration tests for your API endpoints. When the primary consumer of
   the API is a JavaScript client maintained within the same code base as the

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -334,7 +334,7 @@ Ruby JSON APIs
 --------------
 
 * Follow Heroku's [HTTP API Design Guide]
-* Use [`oj`][oj] for parsing JSON
+* Use a fast JSON parser, e.g. [`oj`][oj]
 * Write [request specs] for your API endpoints
 
 [HTTP API Design Guide]: https://github.com/interagent/http-api-design


### PR DESCRIPTION
* Recommend that readers follow Heroku's HTTP API Design Guide when
  developing JSON APIs
* Prefer `oj` for parsing JSON and RSpec request specs for integration
  testing, per iOS on Rails
* References:
  https://github.com/thoughtbot/ios-on-rails/blob/master/book/rails/introduction.md#parsing-incoming-json-requests
  https://github.com/thoughtbot/ios-on-rails/blob/master/book/rails/creating_a_get_request.md#it-all-starts-with-a-request-spec