### PR TITLE
Use blocks when declaring date and time attributes

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -97,7 +97,9 @@ Rails
 * Prefer `Time.zone.parse("2014-07-04 16:05:37")` over `Time.parse("2014-07-04 16:05:37")`
 * Use `ENV.fetch` for environment variables instead of `ENV[]`so that unset
   environment variables are detected on deploy.
+* [Use blocks][date-block] when declaring date and time attributes in FactoryGirl factories.
 
+[date-block]: /best-practices/samples/ruby.rb#L10
 [fkey]: http://robots.thoughtbot.com/referential-integrity-with-foreign-keys
 [`.ruby-version`]: https://gist.github.com/fnichol/1912050
 [redirects]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30

--- a/best-practices/samples/ruby.rb
+++ b/best-practices/samples/ruby.rb
@@ -4,3 +4,9 @@ class PostSerializer < ActiveModel::Serializer
 
   delegate :to_param, to: :object
 end
+
+FactoryGirl.define do
+  factory :event do
+    start_on { 1.week.from_now }
+  end
+end


### PR DESCRIPTION
`FactoryGirl` factories can lazily instantiate values. Since `Date`,
`Time`, and `DateTime` can be affected by utilities such as `Timecop`
and `ActiveSupport` (configured at the test level), we should avoid
instantiating instances until the last possible moment.