### PR TITLE
JavaScript: Avoid referring to `arguments`

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -189,13 +189,15 @@ Email
 
 JavaScript
 ----------
-* Avoid referring to `arguments`.
+* Avoid referring to `arguments`. As an alternative to `arguments`, use the
+  spread syntax with a variable that is not `arguments`. [sample][spread]
 * Use Coffeescript, ES6 with [babel], or another language that compiles to
   JavaScript
 * Include a `to_param` or `href` attribute when serializing ActiveRecord models,
   and use that when constructing URLs client side, rather than the ID. Example:
 
 [babel]: http://babeljs.io/
+[spread]: samples/javascript.js#L1-L3
 
 HTML
 ----

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -189,6 +189,7 @@ Email
 
 JavaScript
 ----------
+* Avoid referring to `arguments`.
 * Use Coffeescript, ES6 with [babel], or another language that compiles to
   JavaScript
 * Include a `to_param` or `href` attribute when serializing ActiveRecord models,

--- a/best-practices/samples/javascript.js
+++ b/best-practices/samples/javascript.js
@@ -1,0 +1,3 @@
+function foo(...args) {
+  // ...
+}


### PR DESCRIPTION
*Avoid* using `arguments` unnecessarily.

Inspired by [petkaantonov/bluebird][wiki]'s "Optimization Killers"
wiki.

Using `arguments` without `.length` or `[i]` makes it nearly impossible
for V8 to optimize the function block.

[wiki]: https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments