### PR TITLE
Add `style/javascript/.jscsrc`

### DIFF
--- a/style/javascript/.jscsrc
+++ b/style/javascript/.jscsrc
@@ -1,0 +1,80 @@
+{
+  "esnext": true,
+  "verbose": true,
+  "disallowEmptyBlocks": true,
+  "disallowKeywordsOnNewLine": ["else"],
+  "disallowMultipleLineBreaks": true,
+  "disallowMultipleVarDecl": "exceptUndefined",
+  "disallowNewlineBeforeBlockStatements": true,
+  "disallowSpaceAfterObjectKeys": true,
+  "disallowSpaceAfterPrefixUnaryOperators": true,
+  "disallowSpaceBeforePostfixUnaryOperators": true,
+  "disallowSpaceBeforeSemicolon": true,
+  "disallowSpacesInFunction": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInsideParentheses": true,
+  "disallowSpacesInCallExpression": true,
+  "disallowTrailingComma": false,
+  "disallowTrailingWhitespace": true,
+  "disallowVar": true,
+  "requireArrayDestructuring": true,
+  "requireBlocksOnNewline": true,
+  "requireCamelCaseOrUpperCaseIdentifiers": false,
+  "requireCapitalizedConstructors": true,
+  "requireCommaBeforeLineBreak": true,
+  "requireCurlyBraces": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "try",
+    "catch",
+    "switch"
+  ],
+  "requireDotNotation": true,
+  "requireEnhancedObjectLiterals": true,
+  "requireLineBreakAfterVariableAssignment": true,
+  "requireObjectDestructuring": true,
+  "requireOperatorBeforeLineBreak": ["."],
+  "requireParenthesesAroundArrowParam": false,
+  "requireSemicolons": true,
+  "requireSpaceAfterBinaryOperators": true,
+  "requireSpaceAfterKeywords": [
+    "do",
+    "for",
+    "if",
+    "else",
+    "switch",
+    "case",
+    "try",
+    "void",
+    "while",
+    "with",
+    "return",
+    "typeof"
+  ],
+  "requireSpaceAfterLineComment": true,
+  "requireSpaceBeforeBinaryOperators": true,
+  "requireSpaceBeforeBlockStatements": true,
+  "requireSpaceBeforeKeywords": [
+    "else",
+    "while",
+    "catch"
+  ],
+  "requireSpaceBeforeObjectValues": true,
+  "requireSpaceBetweenArguments": true,
+  "requireSpacesInFunction": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInConditionalExpression": true,
+  "requireSpacesInForStatement": true,
+  "requireSpacesInsideObjectBrackets": "all",
+  "validateIndentation": 2,
+  "validateParameterSeparator": ", ",
+  "validateQuoteMarks": {
+    "mark": "'",
+    "escape": true
+  }
+}


### PR DESCRIPTION
Inspired by our Ruby styleguide, which has an accompanying
`.rubocop.yml.

Adding a JSCS linter to thoughtbot/guides allows us to configure Hound
to use our company-wide styleguide:

```yml
jscs:
  enabled: true
  config_file: https://raw.githubusercontent.com/thoughtbot/guides/master/style/javascript/.jscsrc
```

Uses new [`JSCS@2.6.x`][jscs] rules.

[jscs]: https://github.com/jscs-dev/node-jscs/releases/tag/v2.6.0