### PR TITLE
Use a leading underscore for memoization

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -27,6 +27,7 @@ Ruby
 * Prefer `if` over `unless`.
 * Use `_` for unused block parameters.
 * Prefix unused variables or parameters with underscore (`_`).
+* Use a leading underscore when defining instance variables for memoization.
 * Use `%{}` for single-line strings needing interpolation and double-quotes.
 * Use `{...}` for single-line blocks. Use `do..end` for multi-line blocks.
 * Use `?` suffix for predicate methods.

--- a/style/ruby/sample.rb
+++ b/style/ruby/sample.rb
@@ -85,6 +85,10 @@ class SomeClass
     method_body
   end
 
+  def memoized_method
+    @_memoized_method ||= 1
+  end
+
   protected
 
   attr_reader :foo, :user_factory


### PR DESCRIPTION
When using an instance variable prefix the variable with an underscore
to discourage direct use of the ivar over the method.