### PR TITLE
Prefer local assets

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -191,6 +191,13 @@ Email
 [MailView]: https://github.com/37signals/mail_view
 [ActionMailer Preview]: http://api.rubyonrails.org/v4.1.0/classes/ActionMailer/Base.html#class-ActionMailer::Base-label-Previewing+emails
 
+Web
+---
+
+* Avoid a Flash of Unstyled Text, even when no cache is available.
+* Avoid rendering delays caused by synchronous loading.
+* Use https instead of http when linking to assets.
+
 JavaScript
 ----------
 * Use Coffeescript, ES6 with [babel], or another language that compiles to


### PR DESCRIPTION
Externally linked assets, such as Typekit, slow down page loading and
rendering. When possible, we should use assets served from the same
domain and connection as the source HTML page, which keeps latency and
load times down.

If we have to use an external asset, we should use https URLs to avoid
leaking the referrer and other information over public channels.