### PR TITLE
Use Forego instead of Foreman to run apps locally

### DIFF
--- a/protocol/rails/README.md
+++ b/protocol/rails/README.md
@@ -40,9 +40,9 @@ variables.
 Delete extra lines in `.env`, leaving only those needed for app to function
 properly. For example: `BRAINTREE_MERCHANT_ID` and `S3_SECRET`.
 
-Use [Foreman](https://github.com/ddollar/foreman) to run the app locally.
+Use [Forego](https://github.com/ddollar/forego) to run the app locally.
 
-    foreman start
+    forego start
 
 It uses your `.env` file and `Procfile` to run processes
 like Heroku's [Cedar](https://devcenter.heroku.com/articles/cedar/) stack.


### PR DESCRIPTION
According to @ddollar he rewrote [Foreman in Go](https://twitter.com/ddollar/status/375398903912620032) saying "It’s faster and avoids Ruby VM complexities." Heroku also removed Foreman from their toolbelt and is using [Forego for local development](https://devcenter.heroku.com/articles/heroku-local).