### PR TITLE
Recommend `belongs_to :relation, touch: true`

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -100,6 +100,7 @@ Rails
 * Use `ENV.fetch` for environment variables instead of `ENV[]`so that unset
   environment variables are detected on deploy.
 * [Use blocks][date-block] when declaring date and time attributes in FactoryGirl factories.
+* Use `touch: true` when declaring `belongs_to` relationships.
 
 [date-block]: /best-practices/samples/ruby.rb#L10
 [fkey]: http://robots.thoughtbot.com/referential-integrity-with-foreign-keys


### PR DESCRIPTION
Based on @sgrif's recommendation (near 17:19) on [The Bike Shed][bikeshed-41].

Thinking about an application's caching strategy and its implications to
the data model is usually put off until some point in the future.

`touch`ing `belongs_to` relationships is a straightforward way to
pre-emptively configure applications to integrate with Rails' russian
doll caching.

Rails 5 will batch `touch`-generated DB writes.

[bikeshed-41]: http://bikeshed.fm/41