### PR TITLE
Add guideline for capitalization in Swift

### DIFF
--- a/style/swift/README.md
+++ b/style/swift/README.md
@@ -12,3 +12,5 @@ Swift
 * Group computed properties below stored properties
 * Use a blank line above and below computed properties
 * Group methods into specific extensions for each level of access control
+* When capitalizing acronyms or initialisms, follow the capitalization of the
+  first letter.

--- a/style/swift/sample.swift
+++ b/style/swift/sample.swift
@@ -70,3 +70,18 @@ private extension MyClass {
 
   }
 }
+
+// MARK: Capitalization
+
+// Types begin with a capital letter
+struct DopeObject {
+  // if the first letter of an acronym is lowercase, the entire thing should
+  // be lowercase
+  let json: AnyObject
+
+  // if the first letter of an acronym is uppercase, the entire thing should
+  // be uppercase
+  static func decodeFromJSON(json: AnyObject) -> DopeObject {
+    return DopeObject(json: json)
+  }
+}


### PR DESCRIPTION
When naming initialisms or acronyms, we should be following the
capitalization of the initial letter.

BAD:

```swift
let Id: String
let userId: String
```

GOOD:

```swift
let id: String
let userID: String
```