### PR TITLE
Add default SCSS-Lint configuration

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -6,3 +6,6 @@ jscs:
 ruby:
   enabled: true
   config_file: style/ruby/.rubocop.yml
+scss:
+  enabled: true
+  config_file: style/sass/.scss-lint.yml

--- a/style/sass/.scss-lint.yml
+++ b/style/sass/.scss-lint.yml
@@ -1,0 +1,237 @@
+# Up-to-date with SCSS-Lint v0.43.2
+
+scss_files: "**/*.scss"
+
+linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+
+  BemDepth:
+    enabled: false
+    max_elements: 1
+
+  BorderZero:
+    enabled: true
+    convention: zero
+
+  ChainedClasses:
+    enabled: false
+
+  ColorKeyword:
+    enabled: true
+
+  ColorVariable:
+    enabled: true
+
+  Comment:
+    enabled: true
+    style: silent
+
+  DebugStatement:
+    enabled: true
+
+  DeclarationOrder:
+    enabled: true
+
+  DisableLinterReason:
+    enabled: false
+
+  DuplicateProperty:
+    enabled: true
+
+  ElsePlacement:
+    enabled: true
+    style: same_line
+
+  EmptyLineBetweenBlocks:
+    enabled: true
+    ignore_single_line_blocks: true
+
+  EmptyRule:
+    enabled: true
+
+  ExtendDirective:
+    enabled: true
+    severity: warning
+
+  FinalNewline:
+    enabled: true
+    present: true
+
+  HexLength:
+    enabled: true
+    style: short
+
+  HexNotation:
+    enabled: false
+    style: lowercase
+
+  HexValidation:
+    enabled: true
+
+  IdSelector:
+    enabled: true
+
+  ImportantRule:
+    enabled: true
+
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+
+  Indentation:
+    enabled: true
+    allow_non_nested_indentation: false
+    character: space
+    width: 2
+
+  LeadingZero:
+    enabled: true
+    style: include_zero
+
+  MergeableSelector:
+    enabled: true
+    force_nesting: true
+
+  NameFormat:
+    enabled: true
+    allow_leading_underscore: true
+    convention: hyphenated_lowercase
+
+  NestingDepth:
+    enabled: true
+    max_depth: 3
+    ignore_parent_selectors: false
+
+  PlaceholderInExtend:
+    enabled: true
+
+  PropertyCount:
+    enabled: false
+    include_nested: false
+    max_properties: 10
+
+  PropertySortOrder:
+    enabled: true
+    ignore_unspecified: false
+    min_properties: 2
+    separate_groups: false
+
+  PropertySpelling:
+    enabled: true
+    extra_properties: []
+    disabled_properties: []
+
+  PropertyUnits:
+    enabled: true
+    global: [
+      'ch', 'em', 'ex', 'rem',
+      'cm', 'in', 'mm', 'pc', 'pt', 'px', 'q',
+      'vh', 'vw', 'vmin', 'vmax',
+      'deg', 'grad', 'rad', 'turn',
+      'ms', 's',
+      'Hz', 'kHz',
+      'dpi', 'dpcm', 'dppx',
+      '%']
+    properties:
+      line-height: []
+
+  PseudoElement:
+    enabled: true
+
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+
+  SelectorDepth:
+    enabled: true
+    max_depth: 3
+
+  SelectorFormat:
+    enabled: false
+    convention: hyphenated_BEM
+
+  Shorthand:
+    enabled: true
+    allowed_shorthands: [1, 2, 3]
+
+  SingleLinePerProperty:
+    enabled: true
+    allow_single_line_rule_sets: true
+
+  SingleLinePerSelector:
+    enabled: true
+
+  SpaceAfterComma:
+    enabled: true
+    style: one_space
+
+  SpaceAfterPropertyColon:
+    enabled: true
+    style: one_space
+
+  SpaceAfterPropertyName:
+    enabled: true
+
+  SpaceAfterVariableName:
+    enabled: true
+
+  SpaceAroundOperator:
+    enabled: true
+    style: one_space
+
+  SpaceBeforeBrace:
+    enabled: true
+    style: space
+    allow_single_line_padding: false
+
+  SpaceBetweenParens:
+    enabled: true
+    spaces: 0
+
+  StringQuotes:
+    enabled: true
+    style: double_quotes
+
+  TrailingSemicolon:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  TrailingZero:
+    enabled: true
+
+  TransitionAll:
+    enabled: true
+
+  UnnecessaryMantissa:
+    enabled: true
+
+  UnnecessaryParentReference:
+    enabled: true
+
+  UrlFormat:
+    enabled: true
+
+  UrlQuotes:
+    enabled: true
+
+  VariableForProperty:
+    enabled: false
+    properties: []
+
+  VendorPrefix:
+    enabled: true
+    identifier_list: base
+
+  ZeroUnit:
+    enabled: true
+
+  Compass::*:
+    enabled: false

--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -1,6 +1,10 @@
 # Sass
 
-[Sample](sample.scss)
+- [Sample](sample.scss)
+- [Default SCSS-Lint configuration](.scss-lint.yml)
+  - This configuration aligns with our team-wide guides below. It does _not_,
+    however, enforce a particular class naming structure (`SelectorFormat`),
+    which is a team decision to be made on a per-project basis.
 
 ## Formatting
 


### PR DESCRIPTION
Ever started working on a project with Hound only to have it bark at things our Sass style guidelines, or your own guidelines (BEM? Or not to BEM?), . Yeah, me too.

This PR adds a “default” SCSS-Lint configuration file, which is based directly off of [SCSS-Lint’s default config](https://github.com/brigade/scss-lint/blob/master/config/default.yml), but aligns to our established, team-wide guides.

It does _not_:
- Enforce any particular class naming structure (`SelectorFormat`), e.g. BEM. This is a personal/project team decision that should be made collaboratively on a per-project basis.
- Enforce _either_ lowercase or uppercase hexadecimal colors (`HexNotation`). Again, we haven’t come to a consensus as a team on this, so it’s one to toggle on a set a style on a per-project basis.

---

One difficult thing I’ve always come across with SCSS-Lint is not just sharing config files (each project has slightly different needs), but also knowing which _version_ of SCSS-Lint a particular config aligns to. So I’ve put a comment at the top of this one here which indicates so.