### PR TITLE
Suggest referencing class by constant in AR macros

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -87,6 +87,8 @@ Rails
   patch level for a project.
 * Use `_url` suffixes for named routes in mailer views and [redirects].  Use
   `_path` suffixes for named routes everywhere else.
+* Use a [class constant rather than the stringified class name][class constant in association]
+  for `class_name` options on ActiveRecord association macros.
 * Validate the associated `belongs_to` object (`user`), not the database column
   (`user_id`).
 * Use `db/seeds.rb` for data that is required in all environments.
@@ -105,6 +107,7 @@ Rails
 [redirects]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30
 [Spring binstubs]: https://github.com/sstephenson/rbenv/wiki/Understanding-binstubs
 [prevent tampering]: http://blog.bigbinary.com/2013/03/19/cookies-on-rails.html
+[class constant in association]: https://github.com/thoughtbot/guides/blob/master/style/rails/sample.rb
 
 Testing
 -------

--- a/style/rails/sample.rb
+++ b/style/rails/sample.rb
@@ -1,5 +1,5 @@
 class SomeClass
-  belongs_to :tree
+  belongs_to :tree, class_name: Plant
   has_many :apples
   has_many :watermelons
 


### PR DESCRIPTION
For ActiveRecord associations where AR can't automatically determine the class for the association, the `class_name` option allows the developer to specify what class should be used. This option can take either the constant of the model class `Person`, or a string that matches the class' name `"Person"`.

Using a string to specify this option postpones feedback that the class might be missing. For example, if my model has an association like this where the `Author` class does not yet exist:

```ruby
    class Post < ActiveRecord::Base
      has_one :author, class_name: "Person"
    end
```

Specs will only fail if they interact with the association. If `class_name` is specified as `class_name: Person`, and `Person` does not exist, an uninitialized constant `NameError` exception will stop all
execution of the application.

There may possibly be some memory-use benefit to creating fewer strings during application initialization, but I think the early failure feedback benefit of this practice provides enough value on its own to recommend it as a best practice.