### PR TITLE
Add `requireTrailingComma` rule to JSCS

### DIFF
--- a/style/javascript/.jscsrc
+++ b/style/javascript/.jscsrc
@@ -71,6 +71,9 @@
   "requireSpacesInConditionalExpression": true,
   "requireSpacesInForStatement": true,
   "requireSpacesInsideObjectBrackets": "all",
+  "requireTrailingComma": {
+    "ignoreSingleLine": true
+  },
   "validateIndentation": 2,
   "validateParameterSeparator": ", ",
   "validateQuoteMarks": {


### PR DESCRIPTION
Add the [`requireTrailingComma`][rule] rule to JSCS configuration.

Enforce the presence of trailing comma's in multi-line array and object
literal declarations.

[rule]: http://jscs.info/rule/requireTrailingComma