### PR TITLE
Use an ORDER BY clause for user-visible queries

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -165,6 +165,9 @@ Postgres
 * Consider a [partial index] for queries on booleans.
 * Constrain most columns as [`NOT NULL`].
 * [Index foreign keys].
+* Use an `ORDER BY` clause on queries where the results will be displayed to a
+  user, as queries without one may return results in a changing, arbitrary
+  order.
 
 [`NOT NULL`]: http://www.postgresql.org/docs/9.1/static/ddl-constraints.html#AEN2444
 [combines multiple indexes]: http://www.postgresql.org/docs/9.1/static/indexes-bitmap-scans.html


### PR DESCRIPTION
> If sorting is not chosen, the rows will be returned in an unspecified
> order. The actual order in that case will depend on the scan and join
> plan types and the order on disk, but it must not be relied on. A
> particular output ordering can only be guaranteed if the sort step is
> explicitly chosen.

http://www.postgresql.org/docs/8.3/static/queries-order.html