### PR TITLE
Trailing comma for object literals and arrays

### DIFF
--- a/style/javascript/README.md
+++ b/style/javascript/README.md
@@ -19,6 +19,9 @@ JavaScript
 * Use `const` for declaring variables that will never be re-assigned, and `let`
   otherwise.
 * Avoid `var` to declare variables.
+* Use a [trailing comma] after each item in a multi-line array or object
+  literal, including the last item.
 
 [template strings]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings
 [arrow functions]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions
+[trailing comma]: /style/javascript/sample.js#L11

--- a/style/javascript/sample.js
+++ b/style/javascript/sample.js
@@ -5,3 +5,8 @@ class Cat {
     return false;
   }
 }
+
+const somePerson = {
+  name: 'Ralph',
+  company: 'thoughtbot',
+};


### PR DESCRIPTION
Why:

* We'd like to explicitly encourage the use of a trailing comma when
  defining multi line JavaScript object literals or arrays.

This PR:

* Adds a guideline for using trailing commas and an example.