### PR TITLE
Remove advice to use coffeescript

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -203,10 +203,9 @@ Web
 
 JavaScript
 ----------
-* Use Coffeescript, ES6 with [babel], or another language that compiles to
-  JavaScript
+* Use the latest stable JavaScript syntax with a transpiler, such as [babel].
 * Include a `to_param` or `href` attribute when serializing ActiveRecord models,
-  and use that when constructing URLs client side, rather than the ID. Example:
+  and use that when constructing URLs client side, rather than the ID.
 
 [babel]: http://babeljs.io/
 


### PR DESCRIPTION
Why:

* More projects have been using JavaScript or JavaScript with a
  transpiler such as babel to get future features of the language.
* Leaving clients a project with CoffeeScript adds an additional
  barrier to finding talent comfortable working on their product.
* ES6 transpiling give most of the benefits we enjoy with CoffeeScript,
  such as classes and object destructuring, without the drawback of a
  different syntax from JavaScript.
* More developers are familiar with JavaScript then CoffeeScript.

This PR:

* Removes the "best practise" of using CoffeeScript.
* Removes CoffeeScript styles.
* Removes an "Example:" with no following example.