### PR TITLE
JavaScript: Disallow multiple `var` declaration

### DIFF
--- a/style/javascript/.jscsrc
+++ b/style/javascript/.jscsrc
@@ -4,7 +4,9 @@
   "disallowEmptyBlocks": true,
   "disallowKeywordsOnNewLine": ["else"],
   "disallowMultipleLineBreaks": true,
-  "disallowMultipleVarDecl": "exceptUndefined",
+  "disallowMultipleVarDecl": {
+    "allExcept": ["undefined"]
+  },
   "disallowNewlineBeforeBlockStatements": true,
   "disallowSpaceAfterObjectKeys": true,
   "disallowSpaceAfterPrefixUnaryOperators": true,


### PR DESCRIPTION
The `disallowMultipleVarDecl` rule already exists in the `.jscsrc`.
Unfortunately, it is invalidly declared.

This commit corrects the declaration.

[rule]: http://jscs.info/rule/disallowMultipleVarDecl