### PR TITLE
Swift: Specify preference for structs over classes

### DIFF
--- a/style/swift/README.md
+++ b/style/swift/README.md
@@ -5,6 +5,8 @@ Swift
 
 * Keep up with the Objective-C style guide above. Will highlight differences
   here.
+* Prefer `struct`s over `class`es wherever possible
+* Default to marking classes as `final`
 * Use `let` whenever possible to make immutable variables
 * Name all parameters in functions and enum cases
 * Use trailing closures

--- a/style/swift/sample.swift
+++ b/style/swift/sample.swift
@@ -2,6 +2,17 @@
 
 import Foundation // or not
 
+// MARK: Types
+
+// Prefer structs over classes
+struct User {
+  let name: String
+}
+
+// When using classes, default to marking them as final
+final class MyViewController: UIViewController {
+}
+
 // MARK: Closures
 
 // Use typealias when closures are referenced in multiple places


### PR DESCRIPTION
Also note that if you _are_ going to use a `class`, you should default
to marking it as `final`.