### PR TITLE
Specify when to use () and Void in func signatures

### DIFF
--- a/style/swift/README.md
+++ b/style/swift/README.md
@@ -16,3 +16,5 @@ Swift
 * Group methods into specific extensions for each level of access control
 * When capitalizing acronyms or initialisms, follow the capitalization of the
   first letter.
+* When using `Void` in function signatures, prefer `()` for arguments and
+  `Void` for return types.

--- a/style/swift/sample.swift
+++ b/style/swift/sample.swift
@@ -95,6 +95,9 @@ struct DopeObject {
   }
 }
 
+// Use () for void arguments and Void for void return types
+let f: () -> Void = { }
+
 // MARK: Guards
 
 // One expression to evaluate and short or no return


### PR DESCRIPTION
We want to avoid ambiguity, especially with our return types. Functions
that return `()` can become hard to read when passed as an argument to a
higher order function. For example:

```swift
func f(g: () -> ()) { }
```

The parens for the return value end up getting lost in the closing
parens for the higher order function. Conversely, by using `Void`:

```swift
func f(g: () -> Void) { }
```

`Void` stands out as a specific type on its own, and doesn't get lost in
a mess of parens.

At the same time, `()` is a nice brief indication that a function takes
no arguments, and mimics the look of an empty tuple. So if you declare
these two functions:

```swift
func fa(g: () -> Void) { }
func fb(g: (a: T) -> Void) { }
```

There is a visual similarity between the two functions.

This is also how Apple prefers to style functions taking or returning
`Void`.