### PR TITLE
Remove callout to Objective-C styleguide in Swift

### DIFF
--- a/style/swift/README.md
+++ b/style/swift/README.md
@@ -3,8 +3,6 @@ Swift
 
 [Sample](sample.swift)
 
-* Keep up with the Objective-C style guide above. Will highlight differences
-  here.
 * Prefer `struct`s over `class`es wherever possible
 * Default to marking classes as `final`
 * Use `let` whenever possible to make immutable variables


### PR DESCRIPTION
We aren't following many (any?) of the guidelines from Objective-C.
There's no real reason to bring attention to it anymore. We should
instead look ahead and add guidelines for Swift without the legacy
baggage.