### PR TITLE
Add line length limit for Swift

### DIFF
--- a/style/swift/README.md
+++ b/style/swift/README.md
@@ -5,6 +5,7 @@ Swift
 
 * Prefer `struct`s over `class`es wherever possible
 * Default to marking classes as `final`
+* Break long lines after 100 characters
 * Use `let` whenever possible to make immutable variables
 * Name all parameters in functions and enum cases
 * Use trailing closures


### PR DESCRIPTION
We should probably have _some_ guideline for line length in Swift. 80
feels too short, since we tend to work with fairly verbose APIs.
SwiftLint has settled on 100 characters, which seems like a reasonable
length.

In Xcode you can add a line length guide inside Preferences -> Text
Editing.

ping @thoughtbot/ios