### PR TITLE
Use 2 spaces for indentation in Swift

### DIFF
--- a/style/swift/README.md
+++ b/style/swift/README.md
@@ -6,6 +6,7 @@ Swift
 * Prefer `struct`s over `class`es wherever possible
 * Default to marking classes as `final`
 * Break long lines after 100 characters
+* Use 2 spaces for indentation
 * Use `let` whenever possible to make immutable variables
 * Name all parameters in functions and enum cases
 * Use trailing closures

--- a/style/swift/sample.swift
+++ b/style/swift/sample.swift
@@ -20,7 +20,7 @@ typealias CoolClosure = (foo: Int) -> Bool
 
 // Use aliased parameter names when function parameters are ambiguous
 func yTown(some: Int, withCallback callback: CoolClosure) -> Bool {
-    return CoolClosure(some)
+  return CoolClosure(some)
 }
 
 // It's OK to use $ variable references if the closure is very short and
@@ -29,11 +29,11 @@ let cool = yTown(5) { $0 == 6 }
 
 // Use full variable names when closures are more complex
 let cool = yTown(5) { foo in
-    if foo > 5 && foo < 0 {
-        return true
-    } else {
-      return false
-    }
+  if foo > 5 && foo < 0 {
+    return true
+  } else {
+    return false
+  }
 }
 
 // MARK: Optionals
@@ -42,44 +42,42 @@ var maybe: Bool?
 
 // Use if-let syntax to unwrap optionals
 if let definitely = maybe {
-    print("This is \(definitely) here")
+  print("This is \(definitely) here")
 }
 
 // If the API you are using has implicit unwrapping you should still use if-let
 func someUnauditedAPI(thing: String!) {
-    if let string = thing {
-        print(string)
-    }
+  if let string = thing {
+    print(string)
+  }
 }
 
 // MARK: Enums
 
 enum Response {
-    case Success(NSData)
-    case Failure(NSError)
+  case Success(NSData)
+  case Failure(NSError)
 }
 
 // When the type is known you can let the compiler infer
 let response: Response = .Success(NSData())
 
 func doSomeWork() -> Response {
-    let data = ...
-    return .Success(data)
+  let data = ...
+  return .Success(data)
 }
 
 switch response {
 case let .Success(data):
-    print("The response returned successfully \(data)")
+  print("The response returned successfully \(data)")
 
 case let .Failure(error):
-    print("An error occured: \(error)")
+  print("An error occured: \(error)")
 }
 
 // Group methods into specific extensions for each level of access control
 private extension MyClass {
-  func doSomethingPrivate() {
-
-  }
+  func doSomethingPrivate() { }
 }
 
 // MARK: Capitalization


### PR DESCRIPTION
This brings Swift inline with the defaults for Ruby and other languages.
The benefit here is that while working outside of Xcode (as some of us
try to do), we can use a consistent setting for indentation instead of
having to special case Swift.

From a visual aspect, I've gotten used to the look of 2 spaces, and I
think it feels nice to move away from the 4 space indentations of
Objective-C.

A few of our projects (internal and external) are already using 2
spaces, and I think in _general_ people have liked it more.

Note that this has already been proposed, but was shot down because we
couldn't come to a real consensus. I'd like to re-poll the team and see
where we stand now.

ping @thoughtbot/ios