### PR TITLE
Advocate using locals to render views

### DIFF
--- a/style/rails/README.md
+++ b/style/rails/README.md
@@ -21,10 +21,14 @@ Rails
 * Use `link_to` for GET requests, and `button_to` for other HTTP verbs.
 * Use new-style `validates :name, presence: true` validations, and put all
   validations for a given column together. [Example][validations].
+* Avoid setting instance variables in controllers; explicitly `render`
+  views with a `locals` option to pass values to views instead.
+  [Example][rendering-views-with-locals].
 
 [order-associations]: /style/rails/sample.rb#L2-L4
 [validations]: /style/rails/sample.rb#L6
 [`app/views/application`]: http://asciicasts.com/episodes/269-template-inheritance
+[rendering-views-with-locals]: /style/rails/sample.rb#L10
 
 Migrations
 ----------

--- a/style/rails/sample.rb
+++ b/style/rails/sample.rb
@@ -1,7 +1,15 @@
-class SomeClass
+class SomeModel < ActiveRecord::Base
+  belongs_to :tree
   belongs_to :tree, class_name: Plant
   has_many :apples
   has_many :watermelons
 
   validates :name, presence: true, uniqueness: true
+end
+
+class PostsController < ActionController::Base
+  def index
+    posts = Post.all
+    render locals: { posts: posts }
+  end
 end


### PR DESCRIPTION
It has [long] been [argued] that using instance variables to pass values
to Rails views isn't the greatest of ideas: Rails twists instance
variables to do something they aren't supposed to do, and if you think
about it, it's unclear how views even have access to variables that live
in a completely different scope. (Hint: they're copied from the
controller to the view at runtime when the view is instantiated.)

In most other languages, views (or templates, as they're sometimes
called) are essentially functions and, as such, when you're rendering a
template and want to give that template access to certain values, you
just pass those values along as arguments.

Is there a way to do this in Rails? Yes, by calling `render` explicitly
and using the `locals` option. So your controller would go from this:

``` ruby
class PostsController < ApplicationController
  def index
    @posts = Post.all
  end
end
```

to this:

``` ruby
class PostsController < ApplicationController
  def index
    posts = Post.all
    render locals: { posts: posts }
  end
end
```

The upside to this approach is that now, views and partials act the same
in terms of how they reference variables, and you can convert a view to
a partial easily.

The downside is that you can no longer easily assert that a view was
rendered with a particular variable, but that's okay, because we don't
write controller specs anyway.

[long]: https://github.com/hashrocket/decent_exposure
[argued]: http://thepugautomatic.com/2013/05/locals/