### PR TITLE
Recommend against `toggleProperty`

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -321,6 +321,7 @@ Ember
 * Prefer dependency injection through `Ember.inject` over initializers, globals
   on window, or namespaces. ([sample][inject])
 * Prefer sub-routes over maintaining state.
+* Prefer explicit setting of boolean properties over `toggleProperty`.
 * Prefer testing your application with [QUnit][ember-test-guides].
 
 [ember-test-guides]: https://guides.emberjs.com/v2.2.0/testing/


### PR DESCRIPTION
Using `toggleProperty` makes tracking down interactions a lot harder. Using explicit actions for what you expect to happens make code easier to maintain and debug.