### PR TITLE
Break up long initializers and functions

### DIFF
--- a/style/swift/README.md
+++ b/style/swift/README.md
@@ -25,3 +25,5 @@ Swift
 * Prefer to name `IBAction` and target/action methods using a verb describing
   the action it will trigger, instead of the user action
   (e.g., `edit:` instead of `editTapped:`)
+* Break up long initializers or function calls by adding linebreaks between
+  arguments.

--- a/style/swift/sample.swift
+++ b/style/swift/sample.swift
@@ -100,3 +100,13 @@ guard let oneItem = somethingFailable(),
 guard let something = somethingFailable() else {
   return someFunctionThatDoesSomethingInManyWordsOrLines()
 }
+
+// Break up long function calls and initializers
+let foo = Foo(
+  bar: Bar(),
+  baz: Baz(),
+  quz: Quz(
+    x: 42,
+    y: 365
+  )
+)


### PR DESCRIPTION
Instead of letting function calls sprawl out, it's more readable to
break them up by adding linebreaks at the argument labels. As an added
benefit, it makes it easy to visually scan the implementation to see
which value is being passed to which argument.
