### PR TITLE
Allow ternary operator

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -6,7 +6,6 @@ Ruby
 * Avoid conditional modifiers (lines that end with conditionals).
 * Avoid multiple assignments per line (`one, two = 1, 2`).
 * Avoid organizational comments (`# Validations`).
-* Avoid ternary operators (`boolean ? true : false`). Use multi-line `if`
   instead to emphasize code branches.
 * Avoid explicit return statements.
 * Avoid using semicolons.


### PR DESCRIPTION
this should be left to the developer's discretion because it is sometimes much more readable than an `if else`