### PR TITLE
Prefer protocol conformance to object inheritance

### DIFF
--- a/style/swift/README.md
+++ b/style/swift/README.md
@@ -5,6 +5,7 @@ Swift
 
 * Prefer `struct`s over `class`es wherever possible
 * Default to marking classes as `final`
+* Prefer protocol conformance to class inheritance
 * Break long lines after 100 characters
 * Use 2 spaces for indentation
 * Use `let` whenever possible to make immutable variables


### PR DESCRIPTION
Protocol conformance in Swift 2+ is a much more powerful form of
polymorphism than object inheritance and so should be the preferred
method. Among other things, using protocols means that you don't need to
care about the kind of object (struct, enum, or class), which puts way
fewer restrictions on your larger project architecture decisions.
Conversely, since object inheritance can only be achieved with classes,
they force you to make certain decisions about your application
architecture that might have adverse side effects.