### PR TITLE
Reorganize Swift sample code

### DIFF
--- a/style/swift/sample.swift
+++ b/style/swift/sample.swift
@@ -8,11 +8,11 @@ struct User {
 
   // if the first letter of an acronym is lowercase, the entire thing should
   // be lowercase
-  let json: AnyObject
+  let json: Any
 
   // if the first letter of an acronym is uppercase, the entire thing should
   // be uppercase
-  static func decodeFromJSON(json: AnyObject) -> User {
+  static func decode(from json: JSON) -> User {
     return User(json: json)
   }
 }
@@ -27,7 +27,7 @@ final class MyViewController: UIViewController {
 }
 
 // Use typealias when closures are referenced in multiple places
-typealias CoolClosure = Int -> Bool
+typealias CoolClosure = (Int) -> Bool
 
 // Use aliased parameter names when function parameters are ambiguous
 func yTown(some: Int, withCallback callback: CoolClosure) -> Bool {

--- a/style/swift/sample.swift
+++ b/style/swift/sample.swift
@@ -1,13 +1,24 @@
 // Don't include generated header comments
 
-import Foundation // or not
+// MARK: Types and naming
 
-// MARK: Types
-
-// Prefer structs over classes
+// Types begin with a capital letter
 struct User {
   let name: String
+
+  // if the first letter of an acronym is lowercase, the entire thing should
+  // be lowercase
+  let json: AnyObject
+
+  // if the first letter of an acronym is uppercase, the entire thing should
+  // be uppercase
+  static func decodeFromJSON(json: AnyObject) -> User {
+    return User(json: json)
+  }
 }
+
+// Use () for void arguments and Void for void return types
+let f: () -> Void = { }
 
 // When using classes, default to marking them as final
 final class MyViewController: UIViewController {
@@ -15,10 +26,8 @@ final class MyViewController: UIViewController {
   @IBOutlet var button: UIButton!
 }
 
-// MARK: Closures
-
 // Use typealias when closures are referenced in multiple places
-typealias CoolClosure = (foo: Int) -> Bool
+typealias CoolClosure = Int -> Bool
 
 // Use aliased parameter names when function parameters are ambiguous
 func yTown(some: Int, withCallback callback: CoolClosure) -> Bool {
@@ -45,27 +54,11 @@ APIClient.getAwesomeness { [weak self] result in
   self.show(result)
 }
 
-// MARK: Optionals
-
-var maybe: Bool?
-
-// Use if-let syntax to unwrap optionals
-if let definitely = maybe {
-  print("This is \(definitely) here")
-}
-
 // If the API you are using has implicit unwrapping you should still use if-let
 func someUnauditedAPI(thing: String!) {
   if let string = thing {
     print(string)
   }
-}
-
-// MARK: Enums
-
-enum Response {
-  case Success(NSData)
-  case Failure(NSError)
 }
 
 // When the type is known you can let the compiler infer
@@ -84,45 +77,26 @@ case let .Failure(error):
   print("An error occured: \(error)")
 }
 
+// MARK: Organization
+
 // Group methods into specific extensions for each level of access control
 private extension MyClass {
   func doSomethingPrivate() { }
 }
 
-// MARK: Capitalization
-
-// Types begin with a capital letter
-struct DopeObject {
-  // if the first letter of an acronym is lowercase, the entire thing should
-  // be lowercase
-  let json: AnyObject
-
-  // if the first letter of an acronym is uppercase, the entire thing should
-  // be uppercase
-  static func decodeFromJSON(json: AnyObject) -> DopeObject {
-    return DopeObject(json: json)
-  }
-}
-
-// Use () for void arguments and Void for void return types
-let f: () -> Void = { }
-
-// MARK: Guards
+// MARK: Breaking up long lines
 
 // One expression to evaluate and short or no return
-
 guard let singleTest = somethingFailable() else { return }
 guard statementThatShouldBeTrue else { return }
 
 // If there is one long expression to guard or multiple expressions
 // move else to next line
-
 guard let oneItem = somethingFailable(),
   let secondItem = somethingFailable2()
   else { return }
 
 // If the return in else is long, move to next line
-
 guard let something = somethingFailable() else {
   return someFunctionThatDoesSomethingInManyWordsOrLines()
 }


### PR DESCRIPTION
This is kind of a weird change, but this file is fairly unruly and I'm
not sure how best to structure it so that it's useful. I ended up
removing a couple of things that I didn't think were needed and changed
up the sections to be a bit more structured.

It's probably best to read this in a split diff so that you can read the new
version of the file as is. If anyone has any objection to the removal of
things, feel free to speak up.

ping @thoughtbot/ios
