### PR TITLE
Update rubocop.yaml to follow recent changes.

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -334,7 +334,7 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
   Enabled: true
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   Description: 'Checks for trailing comma in parameter lists and literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   EnforcedStyleForMultiline: comma

--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -560,10 +560,6 @@ Rails/Date:
                   such as Date.today, Date.current etc.
   Enabled: false
 
-Rails/DefaultScope:
-  Description: 'Checks if the argument passed to default_scope is a block.'
-  Enabled: false
-
 Rails/FindBy:
   Description: 'Prefer find_by over where.first.'
   Enabled: false


### PR DESCRIPTION
With changes introduced in [0.36.0](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0360-14012016):
- `Rails/DefaultScope` cop was removed.
- `Style/TrailingComma` has been split into `Style/TrailingCommaInArguments` and `Style/TrailingCommaInLiteral`.

`Style/TrailingCommaInLiteral` seemed to fit the spirit of our original rule best.
