### PR TITLE
Add Swift guideline recommending weak references are evaluated once

### DIFF
--- a/style/swift/README.md
+++ b/style/swift/README.md
@@ -20,3 +20,5 @@ Swift
 * When using `Void` in function signatures, prefer `()` for arguments and
   `Void` for return types.
 * Prefer strong IBOutlet references.
+* Avoid evaluating a weak reference multiple times in the same scope.
+  Strongify first, then use the strong reference.

--- a/style/swift/sample.swift
+++ b/style/swift/sample.swift
@@ -38,6 +38,13 @@ let cool = yTown(5) { foo in
   }
 }
 
+// Strongify weak references in async closures
+APIClient.getAwesomeness { [weak self] result in
+  guard let `self` = self else { return }
+  self.stopLoadingSpinner()
+  self.show(result)
+}
+
 // MARK: Optionals
 
 var maybe: Bool?


### PR DESCRIPTION
If a weak reference is evaluated multiple times within the same scope, it's technically possible for the reference to change between `nil` and non-`nil` between references. In order to ensure that valid references remain valid for the entire scope, recommend that weak references are evaluated only once.

The style in the example (using a guard to optionally bind `self`) is just the way I currently do this. It's kind of like using a `@strongify(self)` macro in Objective-C, combined with an early return. Open to suggestions for alternative styles!