### PR TITLE
Use camel case over snake case for readme example

### DIFF
--- a/style/coffeescript/README.md
+++ b/style/coffeescript/README.md
@@ -14,7 +14,7 @@ CoffeeScript
 * Prefer double quotes.
 * Use hyphen-separated filenames, such as `coffee-script.coffee`.
 * Use `PascalCase` for classes, `lowerCamelCase` for variables and functions,
-  `SCREAMING_SNAKE_CASE` for constants, `_single_leading_underscore` for
+  `SCREAMING_SNAKE_CASE` for constants, `_singleLeadingUnderscore` for
   private variables and functions.
 * Use zero spaces before and one space after the colon in a colon assignment
   (i.e. classes, objects).


### PR DESCRIPTION
Since using (lower) camel case is mentioned within the readme, I figured it was a mistake to use snake case over camel case for the private method and variables example. Feel free to close this if I'm wrong, but thought I'd fix it to avoid any possible confusion. :+1:
