### PR TITLE
Prefer private over protected for non-public accessors

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -40,8 +40,8 @@ Ruby
 * Use a trailing comma after each item in a multi-line list, including the last
   item. [Example][trailing comma example]
 * Use heredocs for multi-line strings.
-* Prefer `protected` over `private` for non-public `attr_reader`s, `attr_writer`s,
-  and `attr_accessor`s.
+* Prefer `private` over `protected` for non-public `attr_reader`s,
+  `attr_writer`s, and `attr_accessor`s.
 * Order class methods above instance methods.
 * Prefer method invocation over instance variables.
 

--- a/style/ruby/sample.rb
+++ b/style/ruby/sample.rb
@@ -89,13 +89,11 @@ class SomeClass
     @_memoized_method ||= 1
   end
 
-  protected
+  private
 
   attr_reader :foo, :user_factory
   attr_accessor :bar
   attr_writer :baz
-
-  private
 
   def complex_condition?
     part_one? && part_two?


### PR DESCRIPTION
We added a preference for `protected` over `private` for non-public accessors
in #190. The primary motivation was because Ruby emitted warnings when
declaring private attributes.

In Ruby versions 2.3.0 and greater, Ruby no longer warns about private
attributes, so there's no longer a need to prefer `protected` for attributes.

There was also some discussion about private `attr_writer`s and
`attr_accessor`s, but Ruby allows them in both 2.2 and 2.3.

Changes tested with:

```
$ ruby --version
ruby 2.2.3p172 (2015-08-18) [x86_64-linux]

$ ruby -w style/ruby/sample.rb
style/ruby/sample.rb:94: warning: private attribute?
style/ruby/sample.rb:94: warning: private attribute?
style/ruby/sample.rb:95: warning: private attribute?
style/ruby/sample.rb:96: warning: private attribute?
```

```
$ ruby --version
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-linux]

$ ruby -w style/ruby/sample.rb
```