### PR TITLE
Update Java codeStyleSettings for method chained method call wrapping

### DIFF
--- a/style/android/java/configs/codestyles/thoughtbotAndroid.xml
+++ b/style/android/java/configs/codestyles/thoughtbotAndroid.xml
@@ -156,17 +156,12 @@
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
-    <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
-    <option name="KEEP_LINE_BREAKS" value="false" />
-    <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
     <option name="ALIGN_MULTILINE_FOR" value="false" />
-    <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
-    <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="METHOD_PARAMETERS_WRAP" value="1" />
     <option name="RESOURCE_LIST_WRAP" value="1" />
@@ -174,24 +169,22 @@
     <option name="THROWS_LIST_WRAP" value="1" />
     <option name="EXTENDS_KEYWORD_WRAP" value="1" />
     <option name="THROWS_KEYWORD_WRAP" value="1" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
-    <option name="BINARY_OPERATION_WRAP" value="5" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
     <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+    <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
+    <option name="KEEP_MULTIPLE_EXPRESSIONS_IN_ONE_LINE" value="true" />
     <option name="FOR_STATEMENT_WRAP" value="1" />
     <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
-    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
     <option name="ASSIGNMENT_WRAP" value="1" />
-    <option name="ASSERT_STATEMENT_WRAP" value="1" />
     <option name="IF_BRACE_FORCE" value="1" />
-    <option name="DOWHILE_BRACE_FORCE" value="1" />
-    <option name="WHILE_BRACE_FORCE" value="1" />
-    <option name="CLASS_ANNOTATION_WRAP" value="1" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
     <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
     <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="ENUM_CONSTANTS_WRAP" value="1" />
     <indentOptions>
       <option name="INDENT_SIZE" value="2" />
       <option name="CONTINUATION_INDENT_SIZE" value="4" />


### PR DESCRIPTION
## 🔧 changes
Updated the wrapping logic for chained method calls. These changes allow for more customization around where you want the method calls to be broken up.

## ❓ reason for changes
When working with RxJava it is common to chain a lot of methods to a single observable. Here is the code before these changes

```java
       Observable.combineLatest(googleMap, deals, (map, deal) ->
        map.addMarker(markerOptions(deal))).toList().map(markers -> {
      Builder builder = LatLngBounds.builder();
      for (Marker marker : markers) {
        builder.include(marker.getPosition());
      }
      return builder.build();
    }).subscribe(bounds -> {
      view.panCameraToShowAllMarkers(bounds);
    });
  }
```

After the changes:
```java
    Observable.combineLatest(googleMap, deals, (map, deal) -> map.addMarker(markerOptions(deal)))
        .toList()
        .map(markers -> {
          Builder builder = LatLngBounds.builder();
          for (Marker marker : markers) {
            builder.include(marker.getPosition());
          }
          return builder.build();
        })
        .subscribe(bounds -> {
          view.panCameraToShowAllMarkers(bounds);
        });
```

The "after" version is significantly more readable. You can easily follow all the methods being called on the observable. 
