### PR TITLE
Ensure local master is up to date before merging

### DIFF
--- a/protocol/git/README.md
+++ b/protocol/git/README.md
@@ -106,6 +106,7 @@ View a list of new commits. View changed files. Merge branch into master.
     git log origin/master..<branch-name>
     git diff --stat origin/master
     git checkout master
+    git pull
     git merge <branch-name> --ff-only
     git push
 


### PR DESCRIPTION
We fetched so `origin/master` is up to date, but I think we also need to make sure our local `master` is up to date before merging, so be explicit and add this command.

An alternative could be to `git merge` instead, since we already did the `fetch` part of `git pull`.