### PR TITLE
Place methods and tests for methods in same order

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -44,6 +44,8 @@ Ruby
   `attr_writer`s, and `attr_accessor`s.
 * Order class methods above instance methods.
 * Prefer method invocation over instance variables.
+* When writing tests for a class, place tests for methods in the same order as
+  the methods themselves are listed in the class.
 
 [trailing comma example]: /style/ruby/sample.rb#L49
 [required kwargs]: /style/ruby/sample.rb#L16


### PR DESCRIPTION
When writing tests for a class, it's nice to have the methods and the
tests for those methods listed in the same order. Why? Not because it
makes it easier to find tests (because you can simply use Ctrl-F) or
easier to know where to put new tests (because you could always put them
at the bottom). Really, it's the same argument behind alphabetizing
associations -- it just looks cleaner, and shows attention to detail.
