### PR TITLE
Swift: Force unwrap `segue.destinationViewController`

### DIFF
--- a/style/swift/README.md
+++ b/style/swift/README.md
@@ -22,3 +22,4 @@ Swift
 * Prefer strong IBOutlet references.
 * Avoid evaluating a weak reference multiple times in the same scope.
   Strongify first, then use the strong reference.
+* Force unwrap `segue.destinationViewController` to the type you expect

--- a/style/swift/sample.swift
+++ b/style/swift/sample.swift
@@ -126,3 +126,15 @@ guard let oneItem = somethingFailable(),
 guard let something = somethingFailable() else {
   return someFunctionThatDoesSomethingInManyWordsOrLines()
 }
+
+// MARK: UIKit
+
+final class MyViewController {
+  override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+    switch segue.identifier {
+    case "mySegue"?:
+      let vc = segue.destinationViewController as! MyOtherViewController
+    default: break
+    }
+  }
+}


### PR DESCRIPTION
We should force unwrap the `destinationViewController` on a segue when it
matches one of our identifier.

This causes us to fail as early and loud as possible when
something unexpected happens.

Alternatives considered
-----------------------

**Optional unwrap or guard let/return**:

While this is safer, it will silently not do anything when this isn't a case we
expected. If we're expecting a specific type of vc and it's not that type, we
should be alerted somehow so we can fix it.

**Guard let/fatalError**:

I don't have much of an argument against this one other than it's more verbose.
I don't think the verbosity would improve debugging much so I like the less
verbose version.