### PR TITLE
Swift: Prefer presenting a view controller manually

### DIFF
--- a/style/swift/README.md
+++ b/style/swift/README.md
@@ -22,3 +22,4 @@ Swift
 * Prefer strong IBOutlet references.
 * Avoid evaluating a weak reference multiple times in the same scope.
   Strongify first, then use the strong reference.
+* Prefer presenting a view controller manually over segues

--- a/style/swift/sample.swift
+++ b/style/swift/sample.swift
@@ -126,3 +126,17 @@ guard let oneItem = somethingFailable(),
 guard let something = somethingFailable() else {
   return someFunctionThatDoesSomethingInManyWordsOrLines()
 }
+
+// MARK: UIKit
+
+final class MyViewController {
+  func f() {
+    guard let viewController = self.storyboard?.instantiateViewControllerWithIdentifier(
+      StoryboardIdentifiers.presentedViewController
+    ) else { return }
+    let valueToBeAwareOf = "The presented VC needs to be aware of this value"
+    viewController.property = value
+    presentViewController(viewController, animated: true, completion: .None)
+  }
+}
+


### PR DESCRIPTION
In the discussion about force unwrapping (#430)
`UISegue#destinationViewController` we got sidetracked in talking about
dropping segues all together. This is to continue that discussion
without it intervening with the discussion about force unwrapping.

I feel segues can cause more issues than they're worth. The value in
storyboards is not in segues, but in the visual layout. Segues are
annoying because they pretty much guarantee having to keep state around.
If a value needs to be communicated to the destination of a segue, that
needs to happen in `prepareForSegue`. This decouples presenting the view
controller from configuring it.

By dropping segues we can manually instantiate and configure view
controllers. Initialization can be done using
`UIStoryboard#instantiateViewControllerWithIdentifier`.
