### PR TITLE
Clarify where modules live in classes

### DIFF
--- a/style/rails/README.md
+++ b/style/rails/README.md
@@ -14,7 +14,8 @@ Rails
 * Order ActiveRecord associations above ActiveRecord validations.
 * Order controller contents: filters, public methods, private methods.
 * Order i18n translations alphabetically by key name.
-* Order model contents: constants, macros, public methods, private methods.
+* Order model contents: constants, modules, macros, public methods,
+  private methods.
 * Put application-wide partials in the [`app/views/application`] directory.
 * Use `def self.method`, not the `scope :method` DSL.
 * Use the default `render 'partial'` syntax over `render partial: 'partial'`.


### PR DESCRIPTION
I believe modules (i.e. `include/extend`) should come after constants.

Example:

```
class User < ActiveRecord::Base
  PRIMARY_ATTRIBUTE = "name"

  include Personable

  validates :name, presence: true

  ...

end
```
