### PR TITLE
Trailing comma in Sass maps

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -25,6 +25,7 @@
 * Use parentheses around individual operations in shorthand declarations: `padding: ($variable * 1.5) ($variable * 2);`
 * Use double colons for pseudo-elements
 * Use a `%` unit for the amount/weight when using Sass's color functions: `darken($color, 20%)`, not `darken($color, 20)`
+* Use a trailing comma after each item in a map, including the last item.
 
 ## Order
 

--- a/style/sass/sample.scss
+++ b/style/sass/sample.scss
@@ -17,6 +17,11 @@
   }
 }
 
+$map: (
+  key-1: value-1,
+  key-2: value-2,
+);
+
 .class-two {
   @extend %placeholder;
   @include mixin;


### PR DESCRIPTION
This makes for cleaner diffs when adding to or
removing from the map.

This also aligns with [our JavaScript guideline](https://github.com/thoughtbot/guides/blob/master/style/javascript/sample.js#L11).