### PR TITLE
Disable UrlFormat linter

### DIFF
--- a/style/sass/.scss-lint.yml
+++ b/style/sass/.scss-lint.yml
@@ -231,7 +231,7 @@ linters:
     enabled: true
 
   UrlFormat:
-    enabled: true
+    enabled: false
 
   UrlQuotes:
     enabled: true


### PR DESCRIPTION
This linter is a bit too generalized to have enabled by default.

For example, on the thoughtbot blog we use a CDN for images, so having
an external domain with protocol makes sense, but this linter will throw
a warning.

Reference: https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#urlformat