### PR TITLE
[Rubocop] Disable FrozenStringLiteralComment

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -148,6 +148,12 @@ Style/FileName:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Description: >-
+    Add the frozen_string_literal comment to the top of files
+    to help transition from Ruby 2.3.0 to Ruby 3.0.
+  Enabled: false
+
 Style/FlipFlop:
   Description: 'Checks for flip flops'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'


### PR DESCRIPTION
RuboCop, somewhat recently, added the
[Style/FrozenStringLiteralComment][1] cop, which enforces the presence
of the `# frozen_string_literal: true` pragma at the top of every file,
when running in Ruby 2.3 mode. Hound recently [configured][2] RuboCop to
run in Ruby 2.3 mode by default. This means Hound will now comment on
any Ruby file touched in a PR that doesn't have the pragma, with:

> Missing frozen string literal comment.

This is intended to prepare code bases for Ruby 3.0, where strings will
be frozen by default. In practice, I find Hound making these comments to
be quite annoying, and I have disabled it on my current project.

It seems we can disable the cop, or start putting the pragma at the top
of all our files. The former seems easier so it's my pick.

[1]: https://github.com/bbatsov/rubocop/pull/2542
[2]: https://github.com/houndci/linters/pull/65