### PR TITLE
Change DeprecatedHashMethods to PreferredHashMethods

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -100,7 +100,7 @@ Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: false
 
-Style/DeprecatedHashMethods:
+Style/PreferredHashMethods:
   Description: 'Checks for use of deprecated Hash methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-key'
   Enabled: false


### PR DESCRIPTION
This change was officially made in June, and raises a warning when
running rubocop.

"Warning: unrecognized cop Style/DeprecatedHashMethods"

https://github.com/bbatsov/rubocop/issues/3224
