### PR TITLE
Dis-encourage use of Sass glob imports

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -60,3 +60,4 @@
 * Use [Normalize](https://github.com/necolas/normalize.css) for browser rendering consistency, rather than a reset.
 * Use HTML structure for ordering of selectors. Don't just put styles at the bottom of the Sass file.
 * Avoid having files longer than 100 lines.
+* Do not use `/*` or `**/*` glob imports.


### PR DESCRIPTION
@jaclynperrone and I just ran into this first bullet (new to me). I've historically avoided doing it for the other bullets. 

* It burries errors in development (shows generic 500 page)
* It is gem-dependant. `sass-rails` handles it, or `sass-globbing` gem
* Developer loses nice-looking history of `@import` adds


Also, in legacy codebases, converting **to** a glob import can result in specificity changes due to load-order dependency.