### PR TITLE
Rails: avoid selecting all columns in SQL views

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -160,6 +160,7 @@ Relational Databases
 
 * [Index foreign keys].
 * Constrain most columns as [`NOT NULL`].
+* In a SQL view, only select columns you need (i.e., avoid `SELECT table.*`).
 * Use an `ORDER BY` clause on queries where the results will be displayed to a
   user, as queries without one may return results in a changing, arbitrary
   order.


### PR DESCRIPTION
In SQL views, it can be tempting to grab all of the columns from a table the view relies on:

```sql
SELECT messages.*, notifications.*
FROM ...
```

However, when the database freezes the view's definition, these columns get expanded based on the current state of the database:

```sql
SELECT
messages.id,
messages.content,
messages.user_id,
notifications.id,
notifications.device_id,
notifications...
```

Which causes the view to become very fragile, since changes in any referenced tables can break it (even if they don't change columns the view _actually_ needs). Instead, views should opt to only select columns they specifically need.