### PR TITLE
Add Haml Hound configuration

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,6 +1,9 @@
 coffeescript:
   enabled: true
   config_file: style/coffeescript/coffeelint.json
+haml:
+  enabled: true
+  config_file: style/haml/haml.yml
 javascript:
   enabled: false
 jscs:

--- a/style/haml/haml.yml
+++ b/style/haml/haml.yml
@@ -1,0 +1,70 @@
+# Whether to ignore frontmatter at the beginning of HAML documents for
+# frameworks such as Jekyll/Middleman
+skip_frontmatter: false
+
+linters:
+  AltText:
+    enabled: false
+
+  ClassAttributeWithStaticValue:
+    enabled: true
+
+  ClassesBeforeIds:
+    enabled: true
+
+  ConsecutiveComments:
+    enabled: true
+
+  ConsecutiveSilentScripts:
+    enabled: true
+    max_consecutive: 2
+
+  EmptyScript:
+    enabled: true
+
+  HtmlAttributes:
+    enabled: true
+
+  ImplicitDiv:
+    enabled: true
+
+  LeadingCommentSpace:
+    enabled: true
+
+  LineLength:
+    enabled: true
+    max: 80
+
+  MultilinePipe:
+    enabled: true
+
+  MultilineScript:
+    enabled: true
+
+  ObjectReferenceAttributes:
+    enabled: true
+
+  RuboCop:
+    enabled: false
+
+  RubyComments:
+    enabled: true
+
+  SpaceBeforeScript:
+    enabled: true
+
+  SpaceInsideHashAttributes:
+    enabled: true
+    style: space
+
+  TagName:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  UnnecessaryInterpolation:
+    enabled: true
+
+  UnnecessaryStringOutput:
+    enabled: true


### PR DESCRIPTION
Before, Hound had its own default Haml configuration. We are moving these configurations into specific organisations. Added a thoughtbot-specific Hound configuration for Haml files.

https://trello.com/c/HY2hoTdq

![](http://i.giphy.com/26FL2NwYBOq3Z6C6Q.gif)