### PR TITLE
Remove HTML best practices

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -212,8 +212,6 @@ JavaScript
 HTML
 ----
 
-* Don't use a reset button for forms.
-* Prefer cancel links to cancel buttons.
 * Use `<button>` tags over `<a>` tags for actions.
 
 CSS


### PR DESCRIPTION
These two guides were introduced in https://github.com/thoughtbot/guides/commit/2360fac0c44de00cd37607cdc72b24128adfc7a7 (carried over from the old thoughtbot development handbook).

Does anyone know why these should be considered best practices? I’m not aware of a reason why reset buttons should not be used.

I recently worked on a project which had a filtering features, and it was a situation where it could make sense to have a “Clear filters“ button that would reset the filters form.

- "Don't use a reset button for forms." feels like too strong of a statement and
casts a wide net.
- It is unclear why these are best practices.
- These guidelines are highly dependent on the situation. 
- They lack contextual information on when these best practices should
be adhered to or broken.