### PR TITLE
Drop IE10 from browser support best practice

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -241,7 +241,7 @@ Sass
 Browsers
 --------
 
-* Avoid supporting versions of Internet Explorer before IE10.
+* Avoid supporting versions of Internet Explorer before IE11.
 
 Objective-C
 -----------


### PR DESCRIPTION
Can I Use (with data from StatCounter) reports that global IE10 usage has
dropped to 0.24%: http://caniuse.com/usage-table.