### PR TITLE
Explicit `dependent` on ActiveRecord associations.

### DIFF
--- a/style/rails/README.md
+++ b/style/rails/README.md
@@ -33,8 +33,10 @@ Migrations
 
 * Set an empty string as the default constraint for non-required string and text
   fields. [Example][default example].
+* Set an explicit [`on_delete` behavior for foreign keys][add_foreign_key].
 
 [default example]: migration.rb#L6
+[add_foreign_key]: http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_foreign_key
 
 Routes
 ------

--- a/style/rails/migration.rb
+++ b/style/rails/migration.rb
@@ -4,8 +4,10 @@ class CreateClearanceUsers < ActiveRecord::Migration
       t.timestamps null: false
       t.string :email, null: false
       t.string :name, null: false, default: ''
+      t.references :company
     end
 
     add_index :users, :email
+    add_foreign_key :users, :company_id, on_delete: :restrict
   end
 end


### PR DESCRIPTION
I recently added some missing `dependent: :destroy` settings to associations in a Rails project. I got the following comment on the PR:

> Aside: we (as a person/team/company) should figure out how and when and why to put `dependent: :destroy` on associations. I certainly leave them off, as do others.

I'm as guilty of this as anyone else. It has bitten me in various projects, either because orphaned data was left behind, or more recently—in these glorious days of database-level foreign key constraints—because I couldn't easily delete data from my development environment.

Let's add this to the guides, and ultimately to Hound, so that we get PR comments that make us think about the right thing to do.