### PR TITLE
Prefer curly braces in Ruby

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -29,7 +29,8 @@ Ruby
 * Prefix unused variables or parameters with underscore (`_`).
 * Use a leading underscore when defining instance variables for memoization.
 * Use `%{}` for single-line strings needing interpolation and double-quotes.
-* Use `{...}` for single-line blocks. Use `do..end` for multi-line blocks.
+* Prefer `{...}` for all blocks. Use `do..end` for the special case of passing
+  a block to a method whose arguments should not have parentheses around them.
 * Use `?` suffix for predicate methods.
 * Use `CamelCase` for classes and modules, `snake_case` for variables and
   methods, `SCREAMING_SNAKE_CASE` for constants.


### PR DESCRIPTION
The big difference between `do`/`end` and `{`/`}`, with regards to
blocks, is [precedence].

As a simplification, let's pick one and always use it. How about curly
braces (`{`/`}`) as that one?

Due to precedence, this will not work appropriately for `#it` as we
currently write it. We could use parens around `#it`'s argument:

```ruby
it("redirects to the home page") {
  get :new
  expect(response).to redirect_to(root_url)
}
```

Or we could make it a "prefer" instead of "use", allowing for the
responsible freedom that comes with Ruby's syntax, but clearly stating
our preference.

[precedence]: https://robots.thoughtbot.com/do-end-your-braces