### PR TITLE
Trying to reword potentially de-humanizing guideline

### DIFF
--- a/code-review/README.md
+++ b/code-review/README.md
@@ -31,7 +31,8 @@ Having Your Code Reviewed
 
 * Be grateful for the reviewer's suggestions. ("Good call. I'll make that
   change.")
-* Don't take it personally. The review is of the code, not you.
+* Be aware of [how hard it is to convey emotion online](https://www.fastcodesign.com/3036748/why-its-so-hard-to-detect-emotion-in-emails-and-texts) and how easy it is to
+  misinterpret feedback.
 * Explain why the code exists. ("It's like that because of these reasons. Would
   it be more clear if I rename this class/file/method/variable?")
 * Extract some changes and refactorings into future tickets/stories.

--- a/code-review/README.md
+++ b/code-review/README.md
@@ -31,7 +31,7 @@ Having Your Code Reviewed
 
 * Be grateful for the reviewer's suggestions. ("Good call. I'll make that
   change.")
-* Be aware of [how hard it is to convey emotion online](https://www.fastcodesign.com/3036748/why-its-so-hard-to-detect-emotion-in-emails-and-texts) and how easy it is to
+* Be aware of [how hard it is to convey emotion online] and how easy it is to
   misinterpret feedback.
 * Explain why the code exists. ("It's like that because of these reasons. Would
   it be more clear if I rename this class/file/method/variable?")
@@ -46,6 +46,8 @@ Having Your Code Reviewed
 * Wait to merge the branch until Continuous Integration (TDDium, TravisCI, etc.)
   tells you the test suite is green in the branch.
 * Merge once you feel confident in the code and its impact on the project.
+
+[how hard it is to convey emotion online]: https://www.fastcodesign.com/3036748/why-its-so-hard-to-detect-emotion-in-emails-and-texts
 
 Reviewing Code
 --------------

--- a/code-review/README.md
+++ b/code-review/README.md
@@ -22,8 +22,8 @@ Everyone
 * Don't use sarcasm.
 * Keep it real. If emoji, animated gifs, or humor aren't you, don't force them.
   If they are, use them with aplomb.
-* Talk synchronously (e.g. chat, screensharing, in person) if there are too many 
-  "I didn't understand" or "Alternative solution:" comments. Post a follow-up 
+* Talk synchronously (e.g. chat, screensharing, in person) if there are too many
+  "I didn't understand" or "Alternative solution:" comments. Post a follow-up
   comment summarizing the discussion.
 
 Having Your Code Reviewed
@@ -31,8 +31,8 @@ Having Your Code Reviewed
 
 * Be grateful for the reviewer's suggestions. ("Good call. I'll make that
   change.")
-* Be aware of [how hard it is to convey emotion online] and how easy it is to
-  misinterpret feedback.
+* A common axiom is "Don't take it personally. The review is of the code, not you." We used to include this, but now prefer to say what we mean: Be aware of [how hard it is to convey emotion online] and how easy it is to misinterpret feedback. If a review seems aggressive or angry or otherwise personal, consider if it is intended to be read that way and ask the person for clarification of intent, in person if possible.
+* Keeping the previous point in mind: assume the best intention from the reviewer's comments.
 * Explain why the code exists. ("It's like that because of these reasons. Would
   it be more clear if I rename this class/file/method/variable?")
 * Extract some changes and refactorings into future tickets/stories.


### PR DESCRIPTION
It has been brought to my attention by more than one person that saying "The review is of the code, not you" can be perceived as a way to dehumanize the process of code review and to focus on cold, hard logic ignoring the fact that there's a person on the receiving end of one's feedback.

That was not the original intent, so this attempts to change that guideline's text to instead try to implicitly bring forth the notion that there are emotions involved, and that everyone should be mindful of that. 

Not 100% sure the external link or the current text in the commit are the best way, open to suggestions.