### PR TITLE
SCSS-Lint config updates

### DIFF
--- a/style/sass/.scss-lint.yml
+++ b/style/sass/.scss-lint.yml
@@ -125,7 +125,8 @@ linters:
 
   PropertySpelling:
     enabled: true
-    extra_properties: []
+    extra_properties:
+      - text-decoration-skip
     disabled_properties: []
 
   PropertyUnits:

--- a/style/sass/.scss-lint.yml
+++ b/style/sass/.scss-lint.yml
@@ -12,7 +12,6 @@ linters:
 
   BemDepth:
     enabled: false
-    max_elements: 1
 
   BorderZero:
     enabled: true
@@ -67,7 +66,6 @@ linters:
 
   HexNotation:
     enabled: false
-    style: lowercase
 
   HexValidation:
     enabled: true
@@ -95,8 +93,6 @@ linters:
 
   LengthVariable:
     enabled: false
-    allowed_lengths: []
-    allowed_properties: []
 
   MergeableSelector:
     enabled: true
@@ -117,12 +113,9 @@ linters:
 
   PrivateNamingConvention:
     enabled: false
-    prefix: _
 
   PropertyCount:
     enabled: false
-    include_nested: false
-    max_properties: 10
 
   PropertySortOrder:
     enabled: true
@@ -164,7 +157,6 @@ linters:
 
   SelectorFormat:
     enabled: false
-    convention: hyphenated_BEM
 
   Shorthand:
     enabled: true
@@ -243,7 +235,6 @@ linters:
 
   VariableForProperty:
     enabled: false
-    properties: []
 
   VendorPrefix:
     enabled: true

--- a/style/sass/.scss-lint.yml
+++ b/style/sass/.scss-lint.yml
@@ -175,7 +175,7 @@ linters:
 
   SpaceAfterComment:
     enabled: true
-    style: one_space
+    style: at_least_one_space
     allow_empty_comments: true
 
   SpaceAfterPropertyColon:

--- a/style/sass/.scss-lint.yml
+++ b/style/sass/.scss-lint.yml
@@ -78,8 +78,8 @@ linters:
 
   ImportPath:
     enabled: true
-    leading_underscore: false
-    filename_extension: false
+    leading_underscore: true
+    filename_extension: true
 
   Indentation:
     enabled: true


### PR DESCRIPTION
- Remove options from disabled linters
- Enable `ImportPath` options
  - Throw warnings for leading underscores and file extensions in imports.
- Update SpaceAfterComment linter
  - Allow at least one space, instead of only one space.
- Add `text-decoration-skip` as a known property