### PR TITLE
Revert "Enable ImportPath options"

### DIFF
--- a/style/sass/.scss-lint.yml
+++ b/style/sass/.scss-lint.yml
@@ -78,8 +78,8 @@ linters:
 
   ImportPath:
     enabled: true
-    leading_underscore: true
-    filename_extension: true
+    leading_underscore: false
+    filename_extension: false
 
   Indentation:
     enabled: true


### PR DESCRIPTION
This reverts commit dff58c897cfdcce720c1c0649938be661cc5dba9.

The value of `false` DOES mean that import paths should not have a
leading underscore or its file extension.