### PR TITLE
ruby string interpolation syntax

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -28,7 +28,7 @@ Ruby
 * Use `_` for unused block parameters.
 * Prefix unused variables or parameters with underscore (`_`).
 * Use a leading underscore when defining instance variables for memoization.
-* Use `%{}` for single-line strings needing interpolation and double-quotes.
+* Use `#{}` for single-line strings needing interpolation and double-quotes.
 * Use `{...}` for single-line blocks. Use `do..end` for multi-line blocks.
 * Use `?` suffix for predicate methods.
 * Use `CamelCase` for classes and modules, `snake_case` for variables and


### PR DESCRIPTION
update for ruby style guide to use correct `#{}` format for string interpolation instead of `%{}`