### PR TITLE
Change Elixir line length rules

### DIFF
--- a/style/elixir/README.md
+++ b/style/elixir/README.md
@@ -9,3 +9,4 @@ Elixir
 * Don't indent pipes when not using the match operator (`=`).
 * Prefer pattern matching and guards in function definitions over conditionals
   in the function body.
+* Break long lines after 100 characters.


### PR DESCRIPTION
We're consistently running into issues, especially in tests, where it is overkill to break lines at 80 characters. Internally on Elixir projects I've worked on we've had a "soft limit" at 80 and a "hard limit" at 100. Unfortunately this is hard to monitor and the "false positives" from hound lead to me ignoring Hound which is less than ideal.
