### PR TITLE
Simplify guides on over-qualified CSS selectors

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -40,15 +40,11 @@
 ## Selectors
 
 * Don't use ID's for style.
+* Avoid over-qualified selectors: `h1.page-title`, `div > .page-title`
 * Use meaningful names: `$visual-grid-color` not `$color` or `$vslgrd-clr`.
 * Be consistent about naming conventions for classes. For instance, if a project is using BEM, continue using it, and if it's not, do not introduce it.
 * Use ID and class names that are as short as possible but as long as necessary.
-* Avoid using the direct descendant selector `>`.
 * Avoid nesting more than 3 selectors deep.
-* Use HTML tags on vague classes that need a qualifier like `header.application` not `.main`.
-* Avoid using the HTML tag in the class name: `section.news` not `section.news-section`.
-* Avoid using HTML tags on classes for generic markup `<div>`, `<span>`: `.widgets` not `div.widgets`.
-* Avoid using HTML tags on classes with specific class names like `.featured-articles`.
 * Avoid using comma delimited selectors.
 * Avoid nesting within a media query.
 * Don't concatenate selectors using Sass's parent selector (`&`).


### PR DESCRIPTION
- Doing this creates overly specific selectors for no real gain beyond
  developer understanding (which can and should be solved in other
  ways).
- The higher specificity created when using element-qualified selectors
  means that a simple class selector cannot override it later in the
  cascade.
- The problem this guideline aims to solve can be fixed simply by not
  using a vague class name.

This guideline was introduced in https://github.com/thoughtbot/guides/pull/92.