### PR TITLE
Add guide for concatenating selectors

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -51,6 +51,7 @@
 * Avoid using HTML tags on classes with specific class names like `.featured-articles`.
 * Avoid using comma delimited selectors.
 * Avoid nesting within a media query.
+* Don't concatenate selectors using Sass's parent selector (`&`).
 
 ## Organization
 

--- a/style/sass/sample.scss
+++ b/style/sass/sample.scss
@@ -37,4 +37,9 @@ $map: (
       text-decoration: underline;
     }
   }
+
+  // don't concatenate selectors
+  &__child {
+    color: $red;
+  }
 }


### PR DESCRIPTION
By using string concatenation, the real selectors no longer exist in the
codebase's CSS/Sass, making them hard to search for. When someone does
search for a selector which is concatenated during build time, their
search might come up empty which gives the impression that it is unused
code and it could be mistakingly removed.