### PR TITLE
Add exclusion to Rubocop's `BlockLength` rule

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -90,6 +90,13 @@ Metrics/AbcSize:
                  branches, and conditions.
   Enabled: false
 
+Metrics/BlockLength:
+  CountComments: true  # count full line comments?
+  Max: 25
+  ExcludedMethods: []
+  Exclude:
+    - "spec/**/*"
+
 Metrics/CyclomaticComplexity:
   Description: >-
                  A complexity metric that is strongly correlated to the number


### PR DESCRIPTION
Before, we were using Rubocop's default `Metrics/BlockLength` rule. This was causing Hound to warn about long blocks in our specs when we did not want it to. Updated the `Metrics/BlockLength` rule to exclude any spec files.