### PR TITLE
Change SCSS concatenation to interpolation

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -47,7 +47,7 @@
 * Avoid nesting more than 3 selectors deep.
 * Avoid using comma delimited selectors.
 * Avoid nesting within a media query.
-* Don't concatenate selectors using Sass's parent selector (`&`).
+* Don't interpolate selectors using Sass's parent selector (`&`).
 
 ## Organization
 

--- a/style/sass/sample.scss
+++ b/style/sass/sample.scss
@@ -38,7 +38,7 @@ $map: (
     }
   }
 
-  // don't concatenate selectors
+  // don't interpolate selectors
   &__child {
     color: $red;
   }


### PR DESCRIPTION
Not sure what word we want to use (semantics, amirite?). I have been referring to this action as "interpolation" because one string is sort of rendered into the other's class name. 

I have referred to concatenation before as when two classes are joined into a selector to create a modifier like:

```
.parent {
  &.--fancy { };
}
```

Resulting in `parent.parent--fancy { }`.

Thoughts?

Edit: I actually *also* don't nest these, but I think it might be good to just have a separation between the two in speaking. 