### PR TITLE
Fix warnings and an error in rubocop.yml

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -266,7 +266,7 @@ Style/OneLineConditional:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
   Enabled: false
 
-Naming/BinaryOperatorParameter:
+Naming/BinaryOperatorParameterName:
   Description: 'When defining binary operators, name the argument other.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
   Enabled: false

--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -2,7 +2,7 @@ AllCops:
   Exclude:
     - db/schema.rb
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
 
@@ -21,7 +21,7 @@ Style/AsciiComments:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-comments'
   Enabled: false
 
-Style/AsciiIdentifiers:
+Naming/AsciiIdentifiers:
   Description: 'Use only ascii symbols in identifiers.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-identifiers'
   Enabled: false
@@ -141,7 +141,7 @@ Style/EvenOdd:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
   Enabled: false
 
-Style/FileName:
+Naming/FileName:
   Description: 'Use snake_case for source file names.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
   Enabled: false
@@ -266,7 +266,7 @@ Style/OneLineConditional:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
   Enabled: false
 
-Style/OpMethod:
+Naming/BinaryOperatorParameter:
   Description: 'When defining binary operators, name the argument other.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
   Enabled: false
@@ -286,7 +286,7 @@ Style/PerlBackrefs:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers'
   Enabled: false
 
-Style/PredicateName:
+Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
   NamePrefixBlacklist:


### PR DESCRIPTION
Rubocop v0.50.0 moved some cops and renamed them. This means that running rubocop without this change results in a number of warnings, then fails with an error.

To fix the warnings:

- Rename `Style/AccessorMethodName` to `Naming/AccessorMethodName`
- Rename `Style/AsciiIdentifiers` to `Naming/AsciiIdentifiers`
- Rename `Style/FileName` to `Naming/FileName`
- Rename `Style/PredicateName` to `Naming/PredicateName`

To fix the error:

- Rename `Style/OpMethods` to `Naming/BinaryOperatorParameter`

This does not look like it is backwards compatible since renaming `Style/OpMethods` to `Naming/BinaryOperatorParameter` means old versions do not know about the config for that cop. But it does prevent rubocop from bumping against an error.

Also, note that the error has been fixed on rubocop's master branch. As of today that fix has not been pushed to rubygems. Once it has been added to a release, it looks like running rubocop without this change will result in a bunch of warnings, but not an error.

The fix to rubocop: https://github.com/bbatsov/rubocop/commit/e8a61bc118055be131f4d3ae88c6e7e293072818