### PR TITLE
Rename LiteralInCondition to LiteralAsCondition.

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -482,7 +482,7 @@ Lint/HandleExceptions:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
   Enabled: false
 
-Lint/LiteralInCondition:
+Lint/LiteralAsCondition:
   Description: 'Checks of literals used in conditions.'
   Enabled: false
 


### PR DESCRIPTION
This changed with https://github.com/bbatsov/rubocop/pull/4864.

Closes #505.