### PR TITLE
re-add missing reference link

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -29,7 +29,8 @@ Ruby
 * Prefix unused variables or parameters with underscore (`_`). [#335]
 * Use a leading underscore when defining instance variables for memoization.
   [#373]
-* Use `%{}` for single-line strings containing double-quotes that require
+* Use `%{}` for single-line strings containing double-quotes that require 
+  interpolation. [36491dbb9]
 * Use `{...}` for single-line blocks. Use `do..end` for multi-line blocks.
   [0d819844]
 * Use `?` suffix for predicate methods. [0d819844]


### PR DESCRIPTION
looks like reference link for line was inadvertently removed here: https://github.com/thoughtbot/guides/commit/87f3beffa95fb5c3f4d88265387ff46da274be30#diff-01b432206ba056d4f1bdc2d43a7f721aL33