### PR TITLE
Use "dependencies" correctly

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -19,8 +19,8 @@ Object-Oriented Design
 
 * Avoid global variables.
 * Avoid long parameter lists.
-* Limit collaborators of an object (entities an object depends on).
-* Limit an object's dependencies (entities that depend on an object).
+* Limit dependencies of an object (entities an object depends on).
+* Limit an object's dependants (entities that depend on an object).
 * Prefer composition over inheritance.
 * Prefer small methods. Between one and five lines is best.
 * Prefer small classes with a single, well-defined responsibility. When a

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -20,7 +20,7 @@ Object-Oriented Design
 * Avoid global variables.
 * Avoid long parameter lists.
 * Limit dependencies of an object (entities an object depends on).
-* Limit an object's dependants (entities that depend on an object).
+* Limit an object's dependents (entities that depend on an object).
 * Prefer composition over inheritance.
 * Prefer small methods. Between one and five lines is best.
 * Prefer small classes with a single, well-defined responsibility. When a


### PR DESCRIPTION
Looks like the word "dependencies" here was being used to mean the opposite of what it usually means, and "collaborators" was being used instead of "dependencies." I propose "dependencies" instead of "collaborators" and "dependants" instead of the confusing use of "dependencies."