### PR TITLE
Update Rails 'Best Practices' section

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -85,8 +85,6 @@ Rails
   patch level for a project.
 * Use `_url` suffixes for named routes in mailer views and [redirects].  Use
   `_path` suffixes for named routes everywhere else.
-* Use a [stringified class name rather than class constant][class constant in association]
-  for `class_name` options on ActiveRecord association macros.
 * Validate the associated `belongs_to` object (`user`), not the database column
   (`user_id`).
 * Use `db/seeds.rb` for data that is required in all environments.

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -85,7 +85,7 @@ Rails
   patch level for a project.
 * Use `_url` suffixes for named routes in mailer views and [redirects].  Use
   `_path` suffixes for named routes everywhere else.
-* Use a [class constant rather than the stringified class name][class constant in association]
+* Use a [stringified class name rather than class constant][class constant in association]
   for `class_name` options on ActiveRecord association macros.
 * Validate the associated `belongs_to` object (`user`), not the database column
   (`user_id`).

--- a/style/rails/sample.rb
+++ b/style/rails/sample.rb
@@ -1,5 +1,5 @@
 class SomeClass
-  belongs_to :tree, class_name: Plant
+  belongs_to :tree, class_name: 'Plant'
   has_many :apples
   has_many :watermelons
 

--- a/style/rails/sample.rb
+++ b/style/rails/sample.rb
@@ -1,5 +1,5 @@
 class SomeClass
-  belongs_to :tree, class_name: 'Plant'
+  belongs_to :tree, class_name: "Plant"
   has_many :apples
   has_many :watermelons
 


### PR DESCRIPTION
In Rails 5.1:
``` 
DEPRECATION WARNING: Passing a class to the `class_name` is deprecated and will raise an ArgumentError in Rails 5.2. It eagerloads more classes than necessary and potentially creates circular dependencies.
```