### PR TITLE
Add rules for ordering dependencies in Elixir

### DIFF
--- a/style/elixir/README.md
+++ b/style/elixir/README.md
@@ -10,3 +10,6 @@ Elixir
 * Prefer pattern matching and guards in function definitions over conditionals
   in the function body.
 * Break long lines after 100 characters.
+* Order the dependencies of a module as: `use`, `import`, `alias`.
+* Put a empty line between each type of dependency.
+* Sort the dependencies in each section alphabetically.

--- a/style/elixir/sample.ex
+++ b/style/elixir/sample.ex
@@ -1,4 +1,11 @@
 defmodule Sample do
+  use Sample.Web, :controller
+
+  import Thing
+
+  alias MyApp.Post
+  alias MyApp.User
+
   def double(a) when is_binary(a) do
     a
     |> String.downcase


### PR DESCRIPTION
This allows you to view the most "coupled" dependencies at the top as `use` and `import` should be used sparingly.