### PR TITLE
Update CI guidance, remove recommendation to use specific service

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -51,12 +51,11 @@ Ruby Gems
 * Use [Appraisal] to test the gem against multiple versions of gem dependencies
   (such as Rails in a Rails engine).
 * Use [Bundler] to manage the gem's dependencies.
-* Use [Travis CI] for Continuous Integration, indicators showing whether GitHub
-  pull requests can be merged, and to test against multiple Ruby versions.
+* Use continuous integration (CI) to show build status within the code review
+  process and to test against multiple Ruby versions.
 
 [Appraisal]: https://github.com/thoughtbot/appraisal
 [Bundler]: http://bundler.io
-[Travis CI]: http://travis-ci.org
 
 Rails
 -----

--- a/code-review/README.md
+++ b/code-review/README.md
@@ -43,8 +43,8 @@ Having Your Code Reviewed
   able to read individual updates based on their earlier feedback.
 * Seek to understand the reviewer's perspective.
 * Try to respond to every comment.
-* Wait to merge the branch until Continuous Integration (TDDium, TravisCI, etc.)
-  tells you the test suite is green in the branch.
+* Wait to merge the branch until continuous integration (TDDium, Travis CI,
+  CircleCI, etc.) tells you the test suite is green in the branch.
 * Merge once you feel confident in the code and its impact on the project.
 
 [how hard it is to convey emotion online]: https://www.fastcodesign.com/3036748/why-its-so-hard-to-detect-emotion-in-emails-and-texts


### PR DESCRIPTION
We tend to use CircleCI over Travis CI, as is [documented in our Handbook](https://github.com/thoughtbot/handbook/blob/master/developing/continuous-integration.md).