### PR TITLE
Remove guidance to avoid FOUT

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -199,7 +199,6 @@ Email
 Web
 ---
 
-* Avoid a Flash of Unstyled Text, even when no cache is available.
 * Avoid rendering delays caused by synchronous loading.
 * Use HTTPS instead of HTTP when linking to assets.
 


### PR DESCRIPTION
By encouraging people to avoid a Flash of Unstyled Text (FOUT), we are
suggesting that displaying content in a specific web font is more
important than the content itself. This is troublesome because we can
never guarantee that the web font will always load, or always
load "fast".

While FOUT is not ideal, we should instead take a "content-first"
approach, because the content is largely the only reason someone is
visiting the page at all. The speed of the site will always be perceived
as faster with content that is instantly rendered, as opposed to content
that is not rendered during the loading of fonts.

Armed with this "content-first" mindset, people should strategize on how
to load fonts as quickly as possible so that FOUT is *reduced*. Newly
available features like CSS's `font-display` property and the `preload`
value in HTML for the `<link>` element provide standard means for
controlling how fonts are loaded.

For historical context, the original guideline to avoid FOUT was added
in https://github.com/thoughtbot/guides/pull/375