### PR TITLE
Remove mention of concatenated selectors

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -32,10 +32,9 @@
 * Use alphabetical order for declarations.
 * Place `@extends` and `@includes` at the top of your declaration list.
 * Place media queries directly after the declaration list.
-* Place concatenated selectors second.
-* Place pseudo-classes and pseudo-elements third.
-* Place nested elements fourth.
-* Place nested classes fifth.
+* Place pseudo-classes and pseudo-elements second.
+* Place nested elements third.
+* Place nested classes fourth.
 
 ## Selectors
 


### PR DESCRIPTION
We recently added a guideline to not concatenate selectors, so this is no longer relevant. See https://github.com/thoughtbot/guides/commit/423f4e1516379ddd091eae49dc5dfd46eef525f4

Also, it’s not ideal that when we edit this ordering, you have the update the whole list because we’ve spelled out each placement. I intend to tackle this in a separate PR as part of a larger improvement.