### PR TITLE
Remove guidance to use specific libraries/tools

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -50,9 +50,6 @@
 
 ## Organization
 
-* Use Bourbon for a Sass library.
-* Use Neat for a grid framework.
-* Use Bitters/`base` directory for styling element selectors, global variables, global extends and global mixins.
-* Use [Normalize](https://github.com/necolas/normalize.css) for browser rendering consistency, rather than a reset.
+* Use a `base` directory for styling element selectors, global variables, global extends and global mixins.
 * Use HTML structure for ordering of selectors. Don't just put styles at the bottom of the Sass file.
 * Avoid having files longer than 100 lines.


### PR DESCRIPTION
- Authors should pick and use tools based on the needs of the project
- We are amongst an explosion in front-end tooling; suggesting this
  small list of libraries/tools/framework is shortsighted
- "Use Bourbon for a Sass library" is confusing because "Sass library"
  is not a defined "thing" that serves every project equally
- Now that CSS Grid Layout has broad browser support, Neat or any grid
  framework might not be needed
- It was strange to categorize these guidelines under "Organization"
- I have a hunch that this guideline is rooted in a time when Bourbon
  was used primarily as a prefixing library, before Autoprefixer was a
  thing and when prefixes were a core need in any project; this is no
  longer the case today