### PR TITLE
Library decisions go elsewhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,10 @@ open a new pull request.
 Since these are our guides, we want everyone at thoughtbot to see them. We have
 a lot of offices across a lot of timezones, so we leave all PRs open for at
 least a week to get feedback from everyone.
+
+## Content
+
+Decisions about which libraries to use should live in template projects such
+as [Suspenders].
+
+[Suspenders]: https://github.com/thoughtbot/suspenders

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -372,7 +372,6 @@ Ruby JSON APIs
 
 * Review the recommended practices outlined in Heroku's [HTTP API Design Guide]
   before designing a new API.
-* Use a fast JSON parser, e.g. [`oj`][oj]
 * Write integration tests for your API endpoints. When the primary consumer of
   the API is a JavaScript client maintained within the same code base as the
   provider of the API, write [feature specs]. Otherwise write [request specs].


### PR DESCRIPTION
Keep the guides as just that: guides. Our best practices are not the
place to keep decisions about which libraries are best at solving which
problem; that goes in templates and project generators.

Move oj into Suspenders in
https://github.com/thoughtbot/suspenders/pull/923 .

Inspired by #509.