### PR TITLE
Clarify meaning of approval

### DIFF
--- a/code-review/README.md
+++ b/code-review/README.md
@@ -47,7 +47,7 @@ Having Your Code Reviewed
 * Wait to merge the branch until continuous integration (TDDium, Travis CI,
   CircleCI, etc.) tells you the test suite is green in the branch.
 * Merge once you feel confident in the code and its impact on the project.
-* Final editorial control rests with the PR author.
+* Final editorial control rests with the pull request author.
 
 [how hard it is to convey emotion online]: https://www.fastcodesign.com/3036748/why-its-so-hard-to-detect-emotion-in-emails-and-texts
 

--- a/code-review/README.md
+++ b/code-review/README.md
@@ -47,6 +47,7 @@ Having Your Code Reviewed
 * Wait to merge the branch until continuous integration (TDDium, Travis CI,
   CircleCI, etc.) tells you the test suite is green in the branch.
 * Merge once you feel confident in the code and its impact on the project.
+* Final editorial control rests with the PR author.
 
 [how hard it is to convey emotion online]: https://www.fastcodesign.com/3036748/why-its-so-hard-to-detect-emotion-in-emails-and-texts
 
@@ -65,6 +66,7 @@ experience, refactors the existing code). Then:
   them. ("What do you think about using a custom validator here?")
 * Seek to understand the author's perspective.
 * Sign off on the pull request with a :thumbsup: or "Ready to merge" comment.
+* Remember that you are here to provide feedback, not to be a gatekeeper.
 
 Style Comments
 --------------


### PR DESCRIPTION
Based on a conversation that happened in Slack on what "approval" means
in the context of code review. This makes it explicit that the PR author
gets to make the final call on whether to merge or make changes. The
reviewer is there to give feedback, not to act as a gatekeeper.

Ideally, discussion and edits go on until both parties are satisfied. In
the event that this drags on too long or no agreement can be reached,
the author may act unilaterally to merge without making some of the
suggested changes.