### PR TITLE
Add guidance to format JavaScript via Prettier

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -207,8 +207,11 @@ JavaScript
   HTML elements. #462
 * Avoid targeting HTML elements using classes intended for styling
   purposes. #462
+* Use [Prettier] to ensure consistent formatting across the codebase. Run
+  Prettier during CI and, if any files would be changed, fail the build.
 
 [babel]: https://babeljs.io/
+[Prettier]: https://prettier.io/
 
 HTML
 ----


### PR DESCRIPTION
Prettier is the standard for formatting many types of files, including
JavaScript. By standardizing through a community-recommended formatting
tool, we're able to reduce pull request chatter by simplifying
formatting decisions and ensure consistency across the codebase.

As such, we also recommend Prettier be incorporated into any build
processes on CI to ensure no code is committed that hasn't been
formatted through Prettier.

This provides no guidance on how to incorporate this into the build
process; however, one common approach is to add a script to the
repository's `package.json`:

```json
{
  "scripts": {
    "prettier-lint": "prettier -l \"**/*.js\""
  }
}
```