### PR TITLE
Make JS style config consistent with Prettier

### DIFF
--- a/style/javascript/.eslintrc.json
+++ b/style/javascript/.eslintrc.json
@@ -104,7 +104,7 @@
     ],
     "array-bracket-spacing": [
       2,
-      "always"
+      "never"
     ],
     "indent": [
       2,
@@ -115,7 +115,7 @@
     ],
     "quotes": [
       2,
-      "single",
+      "double",
       {
         "avoidEscape": true
       }

--- a/style/javascript/README.md
+++ b/style/javascript/README.md
@@ -9,7 +9,7 @@ JavaScript
 * Prefer [arrow functions] `=>`, over the `function` keyword except when
   defining classes or methods.
 * Use semicolons at the end of each statement.
-* Prefer single quotes.
+* Prefer double quotes.
 * Use `PascalCase` for classes, `lowerCamelCase` for variables and functions,
   `SCREAMING_SNAKE_CASE` for constants, `_singleLeadingUnderscore` for private
   variables and functions.

--- a/style/javascript/sample.js
+++ b/style/javascript/sample.js
@@ -1,4 +1,6 @@
-object = { spacing: true }
+object = { spacing: true };
+
+array = [1, 2, 3];
 
 class Cat {
   canBark() {
@@ -7,6 +9,6 @@ class Cat {
 }
 
 const somePerson = {
-  name: 'Ralph',
-  company: 'thoughtbot',
+  name: "Ralph",
+  company: "thoughtbot"
 };


### PR DESCRIPTION
We currently recommend double quotes and no spaces within arrays for Ruby. This updates our JS style to be consistent with that and adds an example to the `sample.js` config.

I also added a missing semicolon.

Edit: This also makes our eslint config consistent with Prettier.