### PR TITLE
Fix namespace warning in .rubocop.yml

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -152,7 +152,7 @@ Style/FrozenStringLiteralComment:
     to help transition from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Description: 'Checks for flip flops'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
   Enabled: false


### PR DESCRIPTION
Earlier this month it seems Rubocop [moved ](https://github.com/rubocop-hq/rubocop/commit/8c52ab632d0d99e580a7e9fa8276a95c8e7c453c#diff-2245023265ae4cf87d02c8b6ba991139)the `FlipFlop` cop from `Style` to `Lint`. Currently running Rubocop with the provided .rubocop.yml file will throw this warning message.

![image](https://user-images.githubusercontent.com/17581658/51644279-43a31600-1f35-11e9-93e1-3c2cccca3f07.png)

To fix warning:
* Rename `Style/FlipFlop` to `Lint/FlipFlop`
