### PR TITLE
Add guideline to avoid JSONB columns

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -171,6 +171,8 @@ Postgres
 * Avoid multicolumn indexes. Postgres [combines multiple indexes] efficiently.
   Optimize later with a [compound index] if needed.
 * Consider a [partial index] for queries on booleans.
+* Avoid JSONB columns unless you have a strong reason to store an entire JSON
+  document from an external source.
 
 [combines multiple indexes]: http://www.postgresql.org/docs/9.1/static/indexes-bitmap-scans.html
 [compound index]: http://www.postgresql.org/docs/9.2/static/indexes-bitmap-scans.html


### PR DESCRIPTION
These columns are frequently abused to store has-one relationships when
somebody feels some aversion to adding several columns or a new table.

The actual use case for JSONB columns is slim and specific to storing
raw JSON efficiently. With a known schema, it's better to use separate
columns.

JSONB doesn't support the full range of Postgres types and constraints
(for example, there's no date type in JSON), it's more complicated to
index and query JSONB, it doesn't integrate as well with ORMs, and it's
harder to understand the schema when JSONB is involved.