### PR TITLE
Rename cop `Performance/Sample` to `Style/Sample`

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -309,6 +309,13 @@ Style/RegexpLiteral:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
   Enabled: false
 
+Style/Sample:
+  Description: >-
+    Use `sample` instead of `shuffle.first`,
+    `shuffle.last`, and `shuffle[Fixnum]`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
+  Enabled: false
+
 Style/SelfAssignment:
   Description: >-
                  Checks for places where self-assignment shorthand should have
@@ -577,13 +584,6 @@ Performance/FlatMap:
 Performance/ReverseEach:
   Description: 'Use `reverse_each` instead of `reverse.each`.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
-  Enabled: false
-
-Performance/Sample:
-  Description: >-
-                  Use `sample` instead of `shuffle.first`,
-                  `shuffle.last`, and `shuffle[Fixnum]`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
   Enabled: false
 
 Performance/Size:


### PR DESCRIPTION
Since `rubocop` version `0.67.0`, `Performance/Sample` have been changed to `Style/Sample`. (https://github.com/rubocop-hq/rubocop/commit/32ed7d197855b66e16f1ef1a7ecdc409112ead14)