### PR TITLE
SHA-2 is NIST-approved

### DIFF
--- a/security/application.md
+++ b/security/application.md
@@ -184,7 +184,7 @@ one-direction hash. When someone finds a way to generate the same hash for two
 different inputs, the hashing function is considered insecure. The American
 National Institute of Standards and Technology (NIST) maintains [a list of
 approved hash algorithms](https://csrc.nist.gov/Projects/Hash-Functions); as of
-this writing they recommend a SHA-3 algorithm.
+this writing SHA-2 and SHA-3 are approved.
 
 Note that base64 encoding is not a hashing function, since it intentionally can
 be decoded.


### PR DESCRIPTION
The page being linked to is worded in a slightly confusing way but
https://csrc.nist.gov/Projects/Hash-Functions/NIST-Policy-on-Hash-Functions
is more explicit - SHA-2 is an approved hash algorithm.

If there is something other than the linked pages about why
SHA-2 might be considered dangerous, we could link it. But SHA-3
is on the new side (which is its own security risk), so I think
the real message here is "avoid SHA-1" rather than taking a
position on SHA-2 versus SHA-3.