### PR TITLE
Remove link to scss-lint config

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -1,9 +1,9 @@
 # Sass
 
 - [Sample](sample.scss)
-- [Default SCSS-Lint configuration](.scss-lint.yml)
+- [Default stylelint configuration](.stylelintrc.json)
   - This configuration aligns with our team-wide guides below. It does _not_,
-    however, enforce a particular class naming structure (`SelectorFormat`),
+    however, enforce a particular class naming structure,
     which is a team decision to be made on a per-project basis.
 
 ## Formatting


### PR DESCRIPTION
We moved away from scss-lint and are using stylelint instead.

The scss-lint config this links to was removed in
https://github.com/thoughtbot/guides/commit/91ebdf6a3c96a1610a2d8f59ffd6ddd4f78cdd1f