### PR TITLE
Restructure CSS guides

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -9,7 +9,7 @@
 ## Formatting
 
 * Use the SCSS syntax.
-* Use hyphens when naming mixins, extends, classes, functions & variables: `span-columns` not `span_columns` or `spanColumns`.
+* Use hyphens when naming mixins, extends, functions & variables: `span-columns` not `span_columns` or `spanColumns`.
 * Use one space between property and value: `width: 20px` not `width:20px`.
 * Use a blank line above a selector that has styles.
 * Prefer hex color codes `#fff` or `#FFF`.
@@ -27,29 +27,178 @@
 * Use a `%` unit for the amount/weight when using Sass's color functions: `darken($color, 20%)`, not `darken($color, 20)`
 * Use a trailing comma after each item in a map, including the last item.
 
-## Order
-
-* Use alphabetical order for declarations.
-* Place `@extends` and `@includes` at the top of your declaration list.
-* Place media queries directly after the declaration list.
-* Place pseudo-classes and pseudo-elements second.
-* Place nested elements third.
-* Place nested classes fourth.
-
 ## Selectors
 
-* Don't use ID's for style.
-* Avoid over-qualified selectors: `h1.page-title`, `div > .page-title`
 * Use meaningful names: `$visual-grid-color` not `$color` or `$vslgrd-clr`.
-* Be consistent about naming conventions for classes. For instance, if a project is using BEM, continue using it, and if it's not, do not introduce it.
 * Use ID and class names that are as short as possible but as long as necessary.
 * Avoid nesting more than 3 selectors deep.
 * Avoid using comma delimited selectors.
 * Avoid nesting within a media query.
-* Don't concatenate selectors using Sass's parent selector (`&`).
 
 ## Organization
 
 * Use a `base` directory for styling element selectors, global variables, global extends and global mixins.
 * Use HTML structure for ordering of selectors. Don't just put styles at the bottom of the Sass file.
 * Avoid having files longer than 100 lines.
+
+---
+
+## Selectors
+
+### Selector specificity
+
+- Don't use ID selectors.
+- Avoid over-qualified selectors, e.g. `h1.page-title`.
+
+<details>
+
+#### Code examples
+
+`h1.page-title` carries a specificity of 2, but can be reduced to 1 by removing
+the `h1` type selector:
+
+```diff
+-h1.page-title
++.page-title {
+   // …
+ }
+```
+
+#### Motivation
+
+Using an ID in a selector increases its specificity, making it more difficult
+to work with alongside class selectors. Furthermore, because IDs must be unique
+within an HTML document, using them as CSS selectors limits reusability.
+
+#### Resources
+
+- Learn about [how specificity is calculated][specificity-calculation].
+
+[specificity-calculation]: https://www.w3.org/TR/selectors-3/#specificity
+
+</details>
+
+### Selector naming
+
+- Use lowercase characters and hyphens (sometimes referred to as hyphen-case,
+  dash-case, or kebab-case) when naming selectors.
+- Be consistent about naming conventions. For instance, if a project is using
+  BEM, continue using it, and if it's not, don't introduce it.
+- Don't uses Sass parent selectors (`&`) to concatenate selector names.
+
+<details>
+
+#### Code examples
+
+Use lowercase characters and hyphens in selector names:
+
+```scss
+.class-name {
+  // …
+}
+```
+
+Don't concatenate selector names:
+
+```scss
+.class {
+  &__child-class {
+    // …
+  }
+}
+```
+
+#### Motivation
+
+Concatenating selector names makes it more difficult to search and find
+selectors in the codebase.
+
+</details>
+
+## General syntax and formatting
+
+### Declarations block ordering
+
+- Order declarations alphabetically.
+- Order items within the declaration block in the following order:
+    1. Sass at-rules, e.g. `@include`
+    1. CSS properties
+    1. Media queries
+    1. Pseudo-classes
+    1. Pseudo-elements
+    1. Nested elements
+
+<details>
+
+#### Code examples
+
+Alphabetize declarations:
+
+```scss
+.class {
+  display: block;
+  text-align: center;
+  width: 100%;
+}
+```
+
+Alphabetize prefixed properties as if the prefix doesn't exist:
+
+```scss
+.class {
+  font-family: system-ui;
+  -webkit-font-smoothing: antialiased;
+  font-weight: $weight-variable;
+}
+```
+
+Comprehensive example of ordering items within a declaration block:
+
+```scss
+.class {
+  @include size(10px);
+
+  display: block;
+  margin: $spacing-variable;
+
+  @media (min-width: $screen-variable) {
+    padding: $spacing-variable;
+  }
+
+  &:focus {
+    border-color: $color-variable;
+  }
+
+  &::before {
+    content: "";
+  }
+
+  .nested-element {
+    margin: $spacing-variable;
+  }
+}
+```
+
+#### Motivation
+
+Alphabetizing is automatable and is commonly a feature built into
+code editors (see Resources below).
+
+#### Linting
+
+Alphabetical declaration ordering can be linted using stylelint with the
+[stylelint-order][stylelint-order] plugin and its
+`order/properties-alphabetical-order` rule.
+
+[stylelint-order]: https://github.com/hudochenkov/stylelint-order
+
+#### Resources
+
+- Atom users can use the [Sort Lines package][sort-lines], which provides
+  commands and keybindings for alphabetical sorting.
+- Sublime Text users can use the `Edit > Sort Lines` menu item, or press
+  <kbd>F5</kbd> to sort lines alphabetically.
+
+[sort-lines]: https://github.com/atom/sort-lines
+
+</details>


### PR DESCRIPTION
I'd like to propose a restructuring of our guides, specifically our
CSS guides (at least for now).

Some of the pain points I have with the existing guides are:

- The current format (mostly bulleted lists) encourages brevity in our
  guides, which can be good and hopefully makes them easy to grasp, but
  potentially leads to a lack of educating and knowledge sharing within
  our guides.
- When reading the guides, it's difficult to understand the motivation
  or intent behind a guideline. If you're lucky, and with a little leg
  work, you can go through the commit history and find that someone left
  a detailed commit message explaining the "why" behind a specific
  guideline. But that takes extra work, and sometimes leads to not a
  succinct commit message, but instead a lengthy Pull Request with
  lots of back-and-forth. It can be hard to find the original intent.
- There's a lack of code examples that help to explain a guideline,
  next to the guideline. Sometimes we have an inline code snippet, but
  this limits how much we can expand on the code, like showing multiple
  code snippets to explain a guideline. We have a single `sample.scss`
  file to reference, but it's disconnected from the explanation and
  reasoning.
- The current list format, does not allow for deep-linking to specific
  guidelines. When reviewing PRs or talking about our guides, it can
  be useful to provide someone a URL to visit. We can't do that now for
  a specific guideline; only for the heading in which the guideline
  is within.

The changes in this commit hope to tackle some of these pain points by:

- Breaking up the bulleted lists into more logical groupings with
  headings. This allows us to add content that explains the guideline
  in more detail.
- Adding example code blocks, which can improve comprehension of the
  guideline and answer the question "what does this guideline mean, can
  you show me?"
- Adding content around the motivation behind a guideline. This may help
  answer questions like "why do we have this guideline?" and "how is
  this helpful?"
- Adding content on linting and/or other tooling.
- Adding content on related resources, like links to articles or code
  editor settings and tips.
- Wrapping expounding content in `<details>` (which creates a hide/show
  or accordion interaction that is collapsed by default), hopefully
  maintaining the brevity, while still allowing.

**Please note that this only restructures a portion of the CSS guidelines.
I want to get feedback and iterate before spending effort doing that.**