### PR TITLE
Remove erroneous markdown link

### DIFF
--- a/code-review/README.md
+++ b/code-review/README.md
@@ -74,8 +74,6 @@ Style Comments
 Reviewers should comment on missed [style](../style)
 guidelines. Example comment:
 
-    [Style](../style):
-
     > Order resourceful routes alphabetically by name.
 
 An example response to style comments:


### PR DESCRIPTION
Currently, the rendered markdown for this guide has a markdown link in the `pre` tag for this example style comment.

Screenshot...
![Screenshot_6_4_19__3_17_PM](https://user-images.githubusercontent.com/11561578/58910801-16812400-86dc-11e9-9d52-3dab0726a225.png)