### PR TITLE
Prefer < over >

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -54,6 +54,7 @@ Formatting
   `}`.
 * Use [Unix-style line endings][newline explanation] (`\n`).
 * Use [uppercase for SQL key words and lowercase for SQL identifiers].
+* Prefer `<` over `>`. [#556]
 
 
 [dot guideline example]: /style/ruby/sample.rb#L11


### PR DESCRIPTION
From https://www.rubytapas.com/2019/07/25/dont-use-greater-than/ written
by Llewellyn Falco.

We want to express the condition X is greater than 5 and less than 10.
There are eight different ways that you can express this concept in
code, but they all evaluate the same.

```ruby
5 < x && x < 10
x < 10 && 5 < x
10 > x && x > 5
x > 5 && 10 > x
5 < x && 10 > x
x < 10 && x > 5
10 > x && 5 < x
x > 5 && 10 > x
```

This can be quite confusing, what if we only consider ones that use the
less than `<` sign.

```ruby
5 < x && x < 10
x < 10 && 5 < x
```

If we order the known values, we are only left with one option

```ruby
5 < x && x < 10
```

The consistency of always using `<`, and ordering by value in compound
conditionals creates only a single way to express this sort of code.
This can make code easier to read and reason about.