### PR TITLE
Use trailing commas in ERb

### DIFF
--- a/style/erb/README.md
+++ b/style/erb/README.md
@@ -5,4 +5,6 @@ ERb
 
 * When wrapping long lines, keep the method name on the same line as the ERb
   interpolation operator and keep each method argument on its own line.
+* Use a trailing comma after each argument in a multi-line method call,
+  including the last item.
 * Prefer double quotes for attributes.

--- a/style/erb/sample.html.erb
+++ b/style/erb/sample.html.erb
@@ -2,5 +2,5 @@
 
 <%= link_to(
   some_object_with_a_long_name.title,
-  parent_object_child_object_path(some_object_with_a_long_name)
+  parent_object_child_object_path(some_object_with_a_long_name),
 ) %>


### PR DESCRIPTION
We generally encourage trailing commas throughout our guides. For
example, in Sass maps and for multi-line lists in Ruby.

This establishes that guidance for ERb as well, when we have a
mutli-line method call. The trailing comma makes for clean diffs, when
adding or removing argument.