### PR TITLE
Move Ruby-specific styles into Ruby

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -36,22 +36,10 @@ Formatting
 * Avoid inline comments.
 * Break long lines after 80 characters.
 * Delete trailing whitespace.
-* Don't include spaces after `(`, `[` or before `]`, `)`.
 * Don't misspell.
-* Don't vertically align tokens on consecutive lines.
-* If you break up a hash, keep the elements on their own lines and closing curly
-  brace on its own line.
-* Indent continued lines two spaces.
-* Indent private methods equal to public methods.
-* If you break up a chain of method invocations, keep each method invocation on
-  its own line. Place the `.` at the end of each line, except the last.
   [Example][dot guideline example].
-* Use 2 space indentation (no tabs).
-* Use an empty line between methods.
 * Use empty lines around multi-line blocks.
 * Use spaces around operators, except for unary operators, such as `!`.
-* Use spaces after commas, after colons and semicolons, around `{` and before
-  `}`.
 * Use [Unix-style line endings][newline explanation] (`\n`).
 * Use [uppercase for SQL key words and lowercase for SQL identifiers].
 
@@ -68,12 +56,9 @@ Naming
 * Prefer naming classes after domain concepts rather than patterns they
   implement (e.g. `Guest` vs `NullUser`, `CachedRequest` vs `RequestDecorator`).
 * Name the enumeration parameter the singular of the collection.
-* Name variables created by a factory after the factory (`user_factory`
-  creates `user`).
 * Name variables, methods, and classes to reveal intent.
 * Treat acronyms as words in names (`XmlHttpRequest` not `XMLHTTPRequest`),
   even if the acronym is the entire name (`class Html` not `class HTML`).
-* Suffix variables holding a factory with `_factory` (`user_factory`).
 
 Organization
 ------------

--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -11,8 +11,18 @@ Ruby
 * Avoid explicit return statements. [#48]
 * Avoid using semicolons. [#108]
 * Avoid bang (!) method names. Prefer descriptive names. [#122]
+* Don't include spaces after `(`, `[` or before `]`, `)`.
 * Don't use `self` explicitly anywhere except class methods (`def self.method`)
   and assignments (`self.attribute =`). [#89]
+* Don't vertically align tokens on consecutive lines.
+* If you break up a chain of method invocations, keep each method invocation on
+  its own line. Place the `.` at the end of each line, except the last.
+* If you break up a hash, keep the elements on their own lines and closing curly
+  brace on its own line.
+* Indent continued lines two spaces.
+* Indent private methods equal to public methods.
+* Name variables created by a factory after the factory (`user_factory`
+  creates `user`).
 * Prefer nested class and module definitions over the shorthand version
   [Example][class definition example] [#332]
 * Prefer `detect` over `find`. [0d819844]
@@ -27,8 +37,13 @@ Ruby
 * Prefer `if` over `unless`. [#254]
 * Use `_` for unused block parameters. [0d819844]
 * Prefix unused variables or parameters with underscore (`_`). [#335]
+* Suffix variables holding a factory with `_factory` (`user_factory`).
+* Use 2 space indentation (no tabs).
 * Use a leading underscore when defining instance variables for memoization.
   [#373]
+* Use an empty line between methods.
+* Use spaces after commas, after colons and semicolons, around `{` and before
+  `}`.
 * Use `%{}` for single-line strings containing double-quotes that require 
   interpolation. [36491dbb9]
 * Use `{...}` for single-line blocks. Use `do..end` for multi-line blocks.


### PR DESCRIPTION
We have some style guidelines that don't apply to all of the languages
we use. This attempts to move Ruby-specific styles into the Ruby style
guide.