### PR TITLE
[RUBY] Single quotes preferred style

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -346,7 +346,7 @@ Style/SpecialGlobalVars:
 Style/StringLiterals:
   Description: 'Checks if uses of quotes match the configured preference.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-string-literals'
-  EnforcedStyle: double_quotes
+  EnforcedStyle: single_quotes
   Enabled: true
 
 Style/TrailingCommaInArguments:


### PR DESCRIPTION
Why:
- It's default https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringLiterals
- Here it's also default and suggested as default https://github.com/bbatsov/ruby-style-guide#consistent-string-literals (it's his opinion but also adopted by others on a large scale)
- It makes it clearer when interpolation is happening
- Generally cleaner looking

Update:

This: https://github.com/thoughtbot/guides/pull/174#issuecomment-43630455 