### PR TITLE
Hound rubocop version spec

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -11,7 +11,7 @@ javascript:
 jscs:
   enabled: true
   config_file: style/javascript/.jscsrc
-ruby:
+rubocop:
   enabled: true
   config_file: style/ruby/.rubocop.yml
 scss:

--- a/.hound.yml
+++ b/.hound.yml
@@ -14,6 +14,7 @@ jscs:
 rubocop:
   enabled: true
   config_file: style/ruby/.rubocop.yml
+  version: 0.72.0
 scss:
   enabled: false
 stylelint:

--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -2,6 +2,10 @@ AllCops:
   Exclude:
     - db/schema.rb
 
+require:
+  - rubocop-rails
+  - rubocop-performance
+
 Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false


### PR DESCRIPTION
Resolves https://github.com/thoughtbot/guides/issues/529

I believe that the hound-config-file changes here will tell hound to use a newer version of rubocop, and that the rubocop-config-file changes here will tell rubocop to use the appropriate gems for the rails/performance styles.