### PR TITLE
Update .rubocop.yml

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -544,7 +544,7 @@ Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: false
 
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Description: >-
                  Checks for rubocop:disable comments that can be removed.
                  Note: this cop is not disabled when disabling all cops.


### PR DESCRIPTION
Fix this error: `Error: The 'Lint/UnneededCopDisableDirective' cop has been renamed to 'Lint/RedundantCopDisableDirective'.`