### PR TITLE
Remove rails-specific GraphQL guide

### DIFF
--- a/graphql/rails/README.md
+++ b/graphql/rails/README.md
@@ -1,3 +1,0 @@
-# GraphQL on Rails
-
-A guide for building GraphQL servers on Rails.


### PR DESCRIPTION
Closes #574

What changed?
============

We remove the rails-specific graphql guide since it is empty and seems like a duplicate. Our current GraphQL guide can be found at:

https://github.com/thoughtbot/guides/blob/master/graphql/README.md