### PR TITLE
Specify ESLint version for Hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -3,6 +3,7 @@ coffeescript:
 eslint:
   enabled: true
   config_file: style/javascript/.eslintrc.json
+  version: 6.3.0
 haml:
   enabled: true
   config_file: style/haml/haml.yml


### PR DESCRIPTION
The default version of ESLint that Hound uses is `4.19.1`. This is
quite an old version, and our ESLint configuration uses features from
newer versions.

This configures Hound to use ESLint v6.3.0, which is the latest version
that Hound supports.

This change should fix some errors you see in thoughtbot PRs, like…

```
Some files could not be reviewed due to errors:
Cannot find module '@thoughtbot/eslint-config'
```

You can see all of the versions that Hound supports here:
http://help.houndci.com/en/articles/2461415-supported-linters