### PR TITLE
Document app/services

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -96,6 +96,7 @@ Rails
   environment variables are detected on deploy.
 * [Use blocks][date-block] when declaring date and time attributes in FactoryBot factories.
 * Use `touch: true` when declaring `belongs_to` relationships.
+* Use `app/models` for model objects and `app/services` for command objects.
 
 [date-block]: /best-practices/samples/ruby.rb#L10
 [fkey]: http://robots.thoughtbot.com/referential-integrity-with-foreign-keys

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -96,7 +96,7 @@ Rails
   environment variables are detected on deploy.
 * [Use blocks][date-block] when declaring date and time attributes in FactoryBot factories.
 * Use `touch: true` when declaring `belongs_to` relationships.
-* Use `app/models` for model objects and `app/services` for command objects.
+* Use `app/models` for domain objects and `app/services` for command objects.
 
 [date-block]: /best-practices/samples/ruby.rb#L10
 [fkey]: http://robots.thoughtbot.com/referential-integrity-with-foreign-keys


### PR DESCRIPTION
Many -- perhaps all -- of our projects have an `app/services` directory.
This diff documents the Platonic ideal of the practice: it is a place for
command objects that orchestrate interactions between two or more
models.

This is in comparison with `app/models`, which holds both ActiveRecord
objects and also data structures related to the app itself.

This is also distinct from `lib`, which is seldom used and often a good
place to move files before extracting them into a gem.

This PR is the result of an internal discussion that happened because of
https://github.com/thoughtbot/suspenders/pull/1015 .