### PR TITLE
Move “Releasing a Ruby Gem”

### DIFF
--- a/how-to/README.rst
+++ b/how-to/README.rst
@@ -53,3 +53,16 @@ capybara-webkit. For example, in ``spec/features/user_signs_in_spec.rb``:
   end
 
 .. _capybara-webkit: https://github.com/thoughtbot/capybara-webkit
+
+... release a Ruby gem
+--------------------------
+
+* Edit the ``VERSION`` constant.
+* Run ``bundle install`` to update ``Gemfile.lock``.
+* Run the test suite.
+* Edit ``NEWS``, ``CHANGELOG``, or ``README`` files if relevant.
+* Commit changes. Use the convention "v2.1.0" in your commit message.
+* Run ``rake release``, which tags the release, pushes the tag
+  to GitHub, and pushes the gem to RubyGems.org_.
+
+.. _RubyGems.org: https://rubygems.org/

--- a/protocol/open-source/README.md
+++ b/protocol/open-source/README.md
@@ -40,14 +40,3 @@ Push:
 Clean up:
 
     git branch -D pr/123
-
-Releasing a Ruby Gem
---------------------
-
-* Edit the `VERSION` constant.
-* Run `bundle install` to update `Gemfile.lock`.
-* Run the test suite.
-* Edit `NEWS`, `Changelog`, or `README` files if relevant.
-* Commit changes. Use the convention "v2.1.0" in your commit message.
-* Run `rake release`, which tags the release, pushes the tag
-  to GitHub, and pushes the gem to Rubygems.org.


### PR DESCRIPTION
I can never seem to find this section on how to release a Ruby gem.
I think it makes more sense as a ‘how-to.’ It’s also not technically
limited to open-source; you can host your gem server, for example.