### PR TITLE
Move pseudo-element guides to Best Practices

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -265,9 +265,11 @@ CSS
   * Prefer `em` units instead of `px` for breakpoint values
   * Start with the smallest viewport size and work upwards using 
     `min-width`/`min-height`
+* Use [double colon syntax][pseudo-element-syntax] for pseudo-elements
 
 [autoprefixer]: https://github.com/postcss/autoprefixer
 [breakpoints]: http://bradfrost.com/blog/post/7-habits-of-highly-effective-media-queries/
+[pseudo-element-syntax]: https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements#Syntax
 
 Sass
 ----

--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -22,7 +22,6 @@
 * Use space around operands: `$variable * 1.5`, not `$variable*1.5`
 * Avoid in-line operations in shorthand declarations (Ex. `padding: $variable * 1.5 variable * 2`)
 * Use parentheses around individual operations in shorthand declarations: `padding: ($variable * 1.5) ($variable * 2);`
-* Use double colons for pseudo-elements
 * Use a `%` unit for the amount/weight when using Sass's color functions: `darken($color, 20%)`, not `darken($color, 20)`
 * Use a trailing comma after each item in a map, including the last item.
 


### PR DESCRIPTION
This is not a guideline about code style. Rather, it's a syntax that is
part of the W3C spec. [According to MDN][mdn]:

> As a rule, double colons (`::`) should be used instead of a single
> colon (`:`). This distinguishes pseudo-classes from pseudo-elements.
> However, since this distinction was not present in older versions of
> the W3C spec, most browsers support both syntaxes for the original
> pseudo-elements.

Therefore, this guideline fits better in the Best Practices section
than in the Style section.

[mdn]: https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements#Syntax