### PR TITLE
Offload stylistic CSS/Sass guides to stylelint

### DIFF
--- a/best-practices/css/README.md
+++ b/best-practices/css/README.md
@@ -1,5 +1,13 @@
 # CSS Best Practices
 
+## Linting
+
+- Use stylelint to lint CSS & Sass
+    - We maintain a [sharable stylelint configuration][stylelint-config]
+      which enforces our guides found in this repo
+
+[stylelint-config]: https://github.com/thoughtbot/stylelint-config
+
 ## Selectors
 
 ### Selector specificity

--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -10,16 +10,8 @@
 
 * Use the SCSS syntax.
 * Use hyphens when naming mixins, extends, functions & variables: `span-columns` not `span_columns` or `spanColumns`.
-* Use one space between property and value: `width: 20px` not `width:20px`.
-* Use a blank line above a selector that has styles.
 * Avoid using shorthand properties for only one value: `background-color: #ff0000;`, not `background: #ff0000;`
 * Use `//` for comment blocks not `/* */`.
-* Use one space between selector and `{`.
-* Use double quotation marks.
-* Use only lowercase, except for hex or string values.
-* Don't add a unit specification after `0` values, unless required by a mixin.
-* Use a leading zero in decimal numbers: `0.5` not `.5`
-* Use space around operands: `$variable * 1.5`, not `$variable*1.5`
 * Avoid in-line operations in shorthand declarations (Ex. `padding: $variable * 1.5 variable * 2`)
 * Use parentheses around individual operations in shorthand declarations: `padding: ($variable * 1.5) ($variable * 2);`
 * Use a `%` unit for the amount/weight when using Sass's color functions: `darken($color, 20%)`, not `darken($color, 20)`


### PR DESCRIPTION
We maintain a [sharable stylelint configuration][stylelint-config] that
enforces many of our CSS & Sass stylistic guides. It's hard to maintain
these guides in two places: here in the Guides written as Markdown and
in a stylelint configuration.

Reading guidelines here in this repo as prose is helpful, but consuming
them via stylelint rules is even better, as stylelint can be integrated
into editors, run in Pull Requests via Hound, and has auto-fixing
capabilities.

This commit removes any Markdown-based guides in this repo for things
which are covered by stylelint in our sharable configuration. It also
adds a ‘Best Practice’ to use stylelint.

Below is a list of which stylelint rule covers the guide being removed:

> Use one space between property and value: `width: 20px` not
> `width:20px`.

This is covered by stylelint's `declaration-colon-space-after` rule:
https://stylelint.io/user-guide/rules/declaration-colon-space-after

> Use a blank line above a selector that has styles.

This is covered by stylelint's `rule-empty-line-before` rule:
https://stylelint.io/user-guide/rules/rule-empty-line-before

> Use one space between selector and `{`.

This is covered by stylelint's `block-opening-brace-space-before` rule:
https://stylelint.io/user-guide/rules/block-opening-brace-space-before

> Use double quotation marks.

This is covered by stylelint's `string-quotes` rule:
https://stylelint.io/user-guide/rules/string-quotes

> Use only lowercase, except for hex or string values.

This is mostly covered by these stylelint rules:

- `color-hex-case`:
  https://stylelint.io/user-guide/rules/color-hex-case
- `property-case`:
  https://stylelint.io/user-guide/rules/property-case
- `selector-pseudo-class-case`:
  https://stylelint.io/user-guide/rules/selector-pseudo-class-case
- `selector-pseudo-element-case`:
  https://stylelint.io/user-guide/rules/selector-pseudo-element-case
- `selector-type-case`:
  https://stylelint.io/user-guide/rules/selector-type-case
- `unit-case`:
  https://stylelint.io/user-guide/rules/unit-case
- `value-keyword-case`:
  https://stylelint.io/user-guide/rules/value-keyword-case

> Don't add a unit specification after `0` values, unless required by
> a mixin.

This is covered by stylelint's `length-zero-no-unit` rule:
https://stylelint.io/user-guide/rules/length-zero-no-unit

> Use a leading zero in decimal numbers: `0.5` not `.5`

This is covered by stylelint's `number-leading-zero` rule:
https://stylelint.io/user-guide/rules/number-leading-zero

> Use space around operands: `$variable * 1.5`, not `$variable*1.5`

This is covered by stylelint-scss's `operator-no-unspaced` rule:
https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/operator-no-unspaced/README.md

> Use double colons for pseudo-elements

This is covered by stylelint's `selector-pseudo-element-colon-notation`
rule:
https://stylelint.io/user-guide/rules/selector-pseudo-element-colon-notation

[stylelint-config]: https://github.com/thoughtbot/stylelint-config