### PR TITLE
Remove hex color preference

### DIFF
--- a/style/sass/README.md
+++ b/style/sass/README.md
@@ -12,7 +12,6 @@
 * Use hyphens when naming mixins, extends, functions & variables: `span-columns` not `span_columns` or `spanColumns`.
 * Use one space between property and value: `width: 20px` not `width:20px`.
 * Use a blank line above a selector that has styles.
-* Prefer hex color codes `#fff` or `#FFF`.
 * Avoid using shorthand properties for only one value: `background-color: #ff0000;`, not `background: #ff0000;`
 * Use `//` for comment blocks not `/* */`.
 * Use one space between selector and `{`.


### PR DESCRIPTION
There are many useful color notations beyond hexadecimal, for example
`rgba()` when you need alpha and `hsl()`/`hsla()` when you want to use
the HSL cylindrical-coordinate system.

Having this guide to prefer hexadecimal feels a bit limiting and I think
people tend to stick to a consistent convention within a project, which
is more important than the specific notation.