### PR TITLE
Remove factory naming style guidline

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -11,8 +11,6 @@ Ruby
 * Avoid ternary operators (`boolean ? true : false`). Use multi-line `if`
   instead to emphasize code branches. [36491dbb9]
 * Avoid bang (!) method names. Prefer descriptive names. [#122]
-* Name variables created by a factory after the factory (`user_factory`
-  creates `user`).
 * Prefer nested class and module definitions over the shorthand version
   [Example][class definition example] [#332]
 * Prefer `detect` over `find`. [0d819844]
@@ -23,7 +21,6 @@ Ruby
   calls. [#183]
 * Use `_` for unused block parameters. [0d819844]
 * Prefix unused variables or parameters with underscore (`_`). [#335]
-* Suffix variables holding a factory with `_factory` (`user_factory`).
 * Use a leading underscore when defining instance variables for memoization.
   [#373]
 * Use `%()` for single-line strings containing double-quotes that require 

--- a/style/ruby/sample.rb
+++ b/style/ruby/sample.rb
@@ -4,7 +4,6 @@ class SomeClass
   def initialize(attributes)
     @some_attribute = attributes[:some_attribute]
     @another_attribute = attributes[:another_attribute]
-    @user_factory = attributes[:user_factory]
   end
 
   def method_with_arguments(argument_one, argument_two)
@@ -74,11 +73,6 @@ class SomeClass
     end
 
     rest_of_body
-  end
-
-  def method_that_uses_factory
-    user = user_factory.new
-    user.ensure_authenticated!
   end
 
   def self.class_method


### PR DESCRIPTION
This guideline was introduced in
https://github.com/thoughtbot/guides/pull/607. While I agree that naming
factories in this way makes sense, I think it is fairly nitpicky. We
already have "Name variables, methods, and classes to reveal intent" in
our [naming style guidelines], which I think implicitly covers something
like this. I don't care what the name of a factory is as
long as it is contextually meaningful.

[naming style guidelines]: https://github.com/thoughtbot/guides/tree/master/style#naming