### PR TITLE
Remove the deprecated jscs configuration

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -9,9 +9,6 @@ haml:
   config_file: style/haml/haml.yml
 javascript:
   enabled: false
-jscs:
-  enabled: true
-  config_file: style/javascript/.jscsrc
 rubocop:
   enabled: true
   config_file: style/ruby/.rubocop.yml


### PR DESCRIPTION
In #457, jscs was switched to eslint, but the configuration was still
left around.