### PR TITLE
Kotlin: prefer .forEach method over for keyword

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -10,3 +10,4 @@
 - Use string resources for all user-visible text.
 - Prefer vector drawables over PNGs or JPEGs.
 - Prefer Model-View-ViewModel (MVVM) for your app architecture.
+- Prefer `.forEach` over the `for` keyword.


### PR DESCRIPTION
These two are equivalent; the `Collections.forEach` method [is an inline
`for`][]. So let's pick one.

[is an inline `for`]: https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/common/src/generated/_Collections.kt#L1814-L1820

I prefer the method syntax since it composes with other methods more
clearly, provides for autocomplete functionality, and promotes an
"objects with behavior"-first thinking (in opposition to C, Java, Rust,
etc., that promotes an imperative mindset).

Some people have [found `.forEach` to be faster][] when [used on a
collection][], somehow, though with worse performance on integer range
loops.

[found `.forEach` to be faster]: https://medium.com/mobile-app-development-publication/kotlin-for-loop-vs-foreach-7eb594960333
[used on a collection]: https://blog.gouline.net/kotlin-bits-for-loops-vs-foreach-30548d7472a5

It's worth noting that the Kotlin style guide has had [an open issue][] on this
topic for four years, with people also leaning towards `.forEach` everywhere.

[an open issue]: https://github.com/Kotlin/kotlin-style-guide/issues/33