### PR TITLE
Avoid returning null from GraphQL operations

### DIFF
--- a/graphql/README.md
+++ b/graphql/README.md
@@ -62,5 +62,6 @@ be used.
 - Provide the ID of the deleted object as a field in mutations that delete
   objects.
 - Use JSON as a default transport format.
+- Avoid returning null from operations. [#630]
 
 [graphql specification]: https://graphql.github.io/graphql-spec/


### PR DESCRIPTION
GraphQL mutations and queries can return `null`, but in practice this
only adds complexity to the client code. Prefer to return a rich data
type instead of a null value.

In graphql-ruby set [`null false`][] in your `BaseQuery` and `BaseMutation`.

[`null false`]: https://www.rubydoc.info/github/rmosolgo/graphql-ruby/GraphQL/Schema/Resolver#null-class_method
