### PR TITLE
Document SuppressLint with a comment

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -11,3 +11,4 @@
 - Prefer vector drawables over PNGs or JPEGs.
 - Prefer Model-View-ViewModel (MVVM) for your app architecture.
 - Prefer `.forEach` over the `for` keyword.
+- Document each `@SuppressLint` with a comment.


### PR DESCRIPTION
The Android linter is an amazing tool. It helps us navigate the unwieldy
world of Android deprecations, bugs, and layout oddities.

It's not perfect, however. The `@SuppressLint` annotation helps us mark
places where we are intentionally bypassing the linter. This allows us
to continue to run the linter while not being bombarded by noise.

However, `@SuppressLint` comes at a cost: it can get out of date, be a
mystery, or be inserted just to silence the linter.

A solution can be a simple comment, describing why the linter was
suppressed and under which conditions it can be invoked again. This can
come in handy when updating a method; if there's a `@SuppressLint`
nearby, check that the comment is still correct. This can also be useful
during a code review: the reviewer gets an understanding of why the
linter was suppressed, and confidence that the developer was not simply
silencing the linter to ignore the error.
