### PR TITLE
Document preference for ActiveStorage

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -112,6 +112,13 @@ others' Rails work, look in particular for:
   is a related todo in the project management system to add it during the
   staging and production deploys.
 
+## Asset Management
+
+- Use [ActiveStorage] to manage file uploads that live on ActiveRecord objects.
+- Don't use live storage backends like S3 or Azure in tests.
+
+[ActiveStorage]: https://guides.rubyonrails.org/active_storage_overview.html
+
 ## How to...
 
 - [Start a New Rails App](./how-to/start_a_new_rails_app.md)


### PR DESCRIPTION
What?
=====

This documents our preference for ActiveStorage when available.

This also explicitly calls out avoiding interacting with storage
providers in a test environment.