### PR TITLE
Collect all Rails migration advice to one location

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -20,13 +20,10 @@
 - Use `link_to` for GET requests, and `button_to` for other HTTP verbs.
 - Use new-style `validates :name, presence: true` validations, and put all
   validations for a given column together. [Example](/rails/sample.rb#L6).
-- [Add foreign key constraints] in migrations.
 - Avoid bypassing validations with methods like `save(validate: false)`,
   `update_attribute`, and `toggle`.
 - Avoid instantiating more than one object in controllers.
 - Avoid naming methods after database columns in the same class.
-- Don't change a migration after it has been merged into `main` if the desired
-  change can be solved with another migration.
 - Don't reference a model class directly from a view.
 - Don't return false from `ActiveModel` callbacks, but instead raise an
   exception.
@@ -36,10 +33,8 @@
   models.
 - Generate necessary [Spring binstubs] for the project, such as `rake` and
   `rspec`, and add them to version control.
-- If there are default values, set them in migrations.
 - Keep `db/schema.rb` or `db/development_structure.sql` under version control.
 - Use only one instance variable in each view.
-- Use SQL, not `ActiveRecord` models, in migrations.
 - Use the [`.ruby-version`] file convention to specify the Ruby version and
   patch level for a project.
 - Use `_url` suffixes for named routes in mailer views and [redirects]. Use
@@ -59,7 +54,6 @@
   FactoryBot factories.
 - Use `touch: true` when declaring `belongs_to` relationships.
 
-[add foreign key constraints]: http://robots.thoughtbot.com/referential-integrity-with-foreign-keys
 [`.ruby-version`]: https://gist.github.com/fnichol/1912050
 [redirects]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30
 [spring binstubs]: https://github.com/sstephenson/rbenv/wiki/Understanding-binstubs
@@ -73,8 +67,14 @@
 - Set an empty string as the default constraint for non-required string and text
   fields. [Example](migration.rb#L6).
 - Set an explicit [`on_delete` behavior for foreign keys].
+- Don't change a migration after it has been merged into `main` if the desired
+  change can be solved with another migration.
+- If there are default values, set them in migrations.
+- Use SQL, not `ActiveRecord` models, in migrations.
+- [Add foreign key constraints] in migrations.
 
 [`on_delete` behavior for foreign keys]: http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_foreign_key
+[add foreign key constraints]: http://robots.thoughtbot.com/referential-integrity-with-foreign-keys
 
 ## Routes
 


### PR DESCRIPTION
Our Rails guide has a section for migration-related advice. However, our
big general advice section still contained several tips about
migrations. This commit moves them under the "migrations" heading to
keep the guide more consistent and easy to scan.