### PR TITLE
Sort ActiveRecord queries by SQL execution order

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -58,6 +58,15 @@
 - [Use blocks](/ruby/sample_2.rb#L10) when declaring date and time attributes in
   FactoryBot factories.
 - Use `touch: true` when declaring `belongs_to` relationships.
+- When building queries with the ActiveRecord interface, sort your method chain
+  as follows since this mirrors the [order SQL actually executes a query]:
+  - `from`
+  - `joins`
+  - `where`
+  - `group`
+  - `having`
+  - `order`
+  - `select`
 
 [add foreign key constraints]: http://robots.thoughtbot.com/referential-integrity-with-foreign-keys
 [`.ruby-version`]: https://gist.github.com/fnichol/1912050
@@ -65,6 +74,7 @@
 [spring binstubs]: https://github.com/sstephenson/rbenv/wiki/Understanding-binstubs
 [prevent tampering]: http://blog.bigbinary.com/2013/03/19/cookies-on-rails.html
 [`app/views/application`]: http://railscasts.com/episodes/269-template-inheritance
+[order SQL actually executes a query]: https://jvns.ca/blog/2019/10/03/sql-queries-don-t-start-with-select
 
 ## Migrations
 


### PR DESCRIPTION
SQL does not execute the parts of a query in the order it is written.
Instead it follows the [following order]:

* `FROM`/`JOIN` and all the `ON` conditions
* `WHERE`
* `GROUP BY`
* `HAVING`
* `SELECT` (including window functions)
* `ORDER BY`
* `LIMIT`

The idea here is that we can better understand what's happening in a
query if we sort the chain of AR methods in the same order that they
will execute.

Additionally, this order is probably also from "most likely to want to
re-use" down to "most likely to want to break off". It's likely we might
want to have a base scope that does some joining and filtering, but that
other methods might want to control how those results are ordered or how
many get returned.

![image](https://user-images.githubusercontent.com/1006966/107245317-036c3e80-69fd-11eb-8851-e2ad7c5a2fac.png)


[following order]: https://jvns.ca/blog/2019/10/03/sql-queries-don-t-start-with-select