### PR TITLE
Rename some cop parameters in Ruby style guide

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -97,7 +97,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   CountComments: true  # count full line comments?
   Max: 25
-  ExcludedMethods: []
+  IgnoredMethods: []
   Exclude:
     - "spec/**/*"
 


### PR DESCRIPTION
Rename `ExcludedMethods` cop parameter to `IgnoredMethods`, as it has been changed in Rubocop 1.5.0.

Note: The old parameter name is still supported, though deprecated.

See https://github.com/rubocop/rubocop/pull/9098 for details.