### PR TITLE
Add example for naming guide

### DIFF
--- a/general/README.md
+++ b/general/README.md
@@ -40,7 +40,7 @@ violations.
   `ReportModule`).
 - Prefer naming classes after domain concepts rather than patterns they
   implement (e.g. `Guest` vs `NullUser`, `CachedRequest` vs `RequestDecorator`).
-- Name the enumeration parameter the singular of the collection.
+- Name the enumeration parameter the singular of the collection (`users.each { |user| greet(user) }`).
 - Name variables, methods, and classes to reveal intent.
 - Treat acronyms as words in names (`XmlHttpRequest` not `XMLHTTPRequest`), even
   if the acronym is the entire name (`class Html` not `class HTML`).


### PR DESCRIPTION
Most other topics had examples, and I thought this specific one was a bit vague without an example.