### PR TITLE
Update scopes guidance in Rails guide

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -15,7 +15,7 @@
 - Order i18n translations alphabetically by key name.
 - Order model contents: constants, macros, public methods, private methods.
 - Put application-wide partials in the [`app/views/application`] directory.
-- Use `def self.method`, not the `scope :method` DSL.
+- Use the `scope :method` DSL, not `def self.method`.
 - Use the default `render 'partial'` syntax over `render partial: 'partial'`.
 - Use `link_to` for GET requests, and `button_to` for other HTTP verbs.
 - Use new-style `validates :name, presence: true` validations, and put all


### PR DESCRIPTION
Before, we used positive instruction to advocate use  of 
`self.method` over [ActiveRecord's](1) `scope :method` DSL.

Using a `scope` means we can chain methods "for free", and
they always return an `ActiveRecord::Relation`. 

[1]: https://guides.rubyonrails.org/active_record_querying.html#scopes