### PR TITLE
Update testing guides to reference system specs

### DIFF
--- a/rails/how-to/feature_test_javascript_in_a_rails_app.md
+++ b/rails/how-to/feature_test_javascript_in_a_rails_app.md
@@ -21,7 +21,7 @@ capybara-webkit. For example, in `spec/system/user_signs_in_spec.rb`:
 
 ```ruby
 describe "Authentication", :js do
-  it "A user signing in" do
+  it "signs in a user" do
     create(:user, email: "me@example.com", password: "sekrit")
 
     sign_in_as email: "me@example.com", password: "sekrit"

--- a/rails/how-to/feature_test_javascript_in_a_rails_app.md
+++ b/rails/how-to/feature_test_javascript_in_a_rails_app.md
@@ -17,11 +17,11 @@ end
 ```
 
 When writing a spec, you must set the `:js` flag for that test to make use of
-capybara-webkit. For example, in `spec/features/user_signs_in_spec.rb`:
+capybara-webkit. For example, in `spec/system/user_signs_in_spec.rb`:
 
 ```ruby
-feature "Authentication", :js do
-  scenario "A user signing in" do
+describe "Authentication", :js do
+  it "A user signing in" do
     create(:user, email: "me@example.com", password: "sekrit")
 
     sign_in_as email: "me@example.com", password: "sekrit"

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -90,11 +90,11 @@
   before designing a new API.
 - Write integration tests for your API endpoints. When the primary consumer of
   the API is a JavaScript client maintained within the same code base as the
-  provider of the API, write [feature specs]. Otherwise write [request specs].
+  provider of the API, write [system specs]. Otherwise write [request specs].
 
 [http api design guide]: https://github.com/interagent/http-api-design
 [oj]: https://github.com/ohler55/oj
-[feature specs]: https://www.relishapp.com/rspec/rspec-rails/docs/feature-specs/feature-spec
+[system specs]: https://relishapp.com/rspec/rspec-rails/docs/system-specs/system-spec
 [request specs]: https://www.relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec
 
 ## How to...

--- a/testing-rspec/README.md
+++ b/testing-rspec/README.md
@@ -24,7 +24,7 @@
 - Don't test private methods.
 - Test background jobs with a [`Delayed::Job` matcher].
 - Use [stubs and spies] \(not mocks\) in isolated tests.
-- Use a single level of abstraction within scenarios.
+- Use a single level of abstraction within `it` examples.
 - Use an `it` example or test method for each execution path through the method.
 - Use [assertions about state] for incoming messages.
 - Use stubs and spies to assert you sent outgoing messages.
@@ -45,17 +45,16 @@
 
 [Sample](acceptance_test_spec.rb)
 
-- Avoid scenario titles that add no information, such as "successfully."
-- Avoid scenario titles that repeat the feature title.
-- Place helper methods for feature specs directly in a top-level `Features`
-  module.
-- Use Capybara's `feature/scenario` DSL.
+- Avoid `it` block descriptions that add no information, such as "successfully."
+- Avoid `it` block descriptions that repeat the top-level `describe` block
+  description.
+- Place helper methods for system specs directly in a top-level `System` module.
 - Use names like `ROLE_ACTION_spec.rb`, such as `user_changes_password_spec.rb`,
-  for feature spec file names.
-- Use only one `feature` block per feature spec file.
-- Use scenario titles that describe the success and failure paths.
-- Use spec/features directory to store feature specs.
-- Use spec/support/features for support code related to feature specs.
+  for system spec file names.
+- Use only one `describe` block per system spec file.
+- Use `it` block descriptions that describe the success and failure paths.
+- Use spec/system directory to store system specs.
+- Use spec/support/system for support code related to system specs.
 
 ## Factories
 

--- a/testing-rspec/README.md
+++ b/testing-rspec/README.md
@@ -56,6 +56,8 @@
 - Use spec/system directory to store system specs.
 - Use spec/support/system for support code related to system specs.
 
+> system specs were previously called feature specs and lived in `spec/features`
+
 ## Factories
 
 - Order `factories.rb` contents: sequences, traits, factory definitions.

--- a/testing-rspec/acceptance_test_spec.rb
+++ b/testing-rspec/acceptance_test_spec.rb
@@ -1,16 +1,17 @@
-# spec/features/user_signing_up_spec.rb
-require 'spec_helper'
+# spec/system/user_signing_up_spec.rb
 
-feature 'User signing up' do
-  scenario 'with valid email and password' do
+require "spec_helper"
+
+describe "User signing up" do
+  it "with valid email and password" do
     visit sign_up_path
 
-    within '#sign_up' do
-      fill_in 'Email', with: 'user@example.com'
-      fill_in 'Password', with: 'Examp1ePa$$'
-      click_button 'Sign up'
+    within "#sign_up" do
+      fill_in "Email", with: "user@example.com"
+      fill_in "Password", with: "Examp1ePa$$"
+      click_button "Sign up"
     end
 
-    expect(page).to have_content('Sign out')
+    expect(page).to have_content("Sign out")
   end
 end

--- a/testing-rspec/acceptance_test_spec.rb
+++ b/testing-rspec/acceptance_test_spec.rb
@@ -1,9 +1,9 @@
-# spec/system/user_signing_up_spec.rb
+# spec/system/user_signs_up_spec.rb
 
 require "spec_helper"
 
-describe "User signing up" do
-  it "with valid email and password" do
+describe "User signs up" do
+  it "signs up the user with valid details" do
     visit sign_up_path
 
     within "#sign_up" do


### PR DESCRIPTION
Before, the guides referred to `feature` specs when outlining best
practices for testing with RSpec.

RSpec now uses [`system specs`][rspec-docs] by default, so this updates the
guides to refer to them.

Guidance around the Capybara `feature/scenario` DSL has been removed,
because it is only an [alias for `describe/it`][capybara-docs]. Removing
that specific guidance, reduces the cognitive overhead of remembering
which style to use when writing different types of RSpec test.

[rspec-docs]: https://relishapp.com/rspec/rspec-rails/docs/system-specs/system-spec
[capybara-docs]: https://github.com/teamcapybara/capybara/blob/master/README.md?plain=1#L222-L224