### PR TITLE
Remove broken link to ruby sample with misspelling

### DIFF
--- a/general/README.md
+++ b/general/README.md
@@ -24,7 +24,7 @@ violations.
 - Avoid inline comments.
 - Break long lines after 80 characters.
 - Delete trailing whitespace.
-- Don't misspell. [Example](/ruby/sample.rb#L11).
+- Don't misspell.
 - Use empty lines around multi-line blocks.
 - Use spaces around operators, except for unary operators, such as `!`.
 - Use [Unix-style line endings] (`\n`).


### PR DESCRIPTION
It linked to https://github.com/thoughtbot/guides/blob/main/ruby/sample.rb#L11

I found https://github.com/thoughtbot/guides/blob/main/ruby/sample_1.rb and https://github.com/thoughtbot/guides/blob/main/ruby/sample_2.rb but didn't find any misspelling.