### PR TITLE
Acceptance Tests: Guidance on `[aria-*]` attributes

### DIFF
--- a/testing-rspec/README.md
+++ b/testing-rspec/README.md
@@ -60,11 +60,19 @@
 - Use `it` block descriptions that describe the success and failure paths.
 - Use spec/system directory to store system specs.
 - Use spec/support/system for support code related to system specs.
+- Don't assert an element's state with `[class]` or `[data-*]` attributes.
+- Use [WAI-ARIA States and Properties][] (i.e. `[role]` or `[aria-*]`
+  attributes) when asserting an element's state.
+- Prefer assertions about implicit semantics and built-in attributes (e.g. an
+  `<input type="checkbox">` element and `[checked]`, an `<option>` element and
+  `[selected]`) over WAI-ARIA States and Properties (e.g. a `<button>` element and
+  `[aria-checked="true"]`, a `<div>` element and `[aria-selected="true"]`).
 
 > system specs were previously called feature specs and lived in `spec/features`
 
 [selectors]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Selector
 [names_and_descriptions]: https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/
+[WAI-ARIA States and Properties]: https://www.w3.org/TR/wai-aria/#states_and_properties
 
 ## Factories
 


### PR DESCRIPTION
When exercising pages that implement behaviors through custom or
third-party widgets, tests might locate elements or drive actions based
on CSS classes (e.g. `.expanded` or `.collapsed`) or `[data-*]`
attributes (e.g. `[data-disclosure-toggled-value="true"]` or
`[data-test-id="toggle-widget"]`).

While these techniques can be helpful work-arounds that exercise the
page, they're low-fidelity alternatives to end-users experiences.

When widgets cannot be exercised by Capybara's suite of selectors or
matchers like `click_on`, test authors should rely on the same sets of
WAI-ARIA compliant attributes that assistive technologies would expect.

For example, if an application's constraints obstruct the author from
implementing a "checkbox" form control with an `<input
type="checkbox">`, the tests that drive the alternative should "check" a
form control with the `[role="checkbox"]` attribute, assert changes to
its `[aria-checked]` attribute, and conform to any of the other expected
attributes and behaviors outlined by the [WAI ARIA Authoring
Practices][wai-aria-checkbox].

[wai-aria-checkbox]: https://www.w3.org/TR/wai-aria-practices/#checkbox