### PR TITLE
Add paired-programming guideline to share end results

### DIFF
--- a/working-together/README.md
+++ b/working-together/README.md
@@ -25,6 +25,8 @@ A guide for working well together.
 
 **After:**
 
+- Share with each other the end results, such as code changes or screenshots,
+  if they're not already accessible by both parties.
 - Ask for Feedback (What did we do well? What could we have done better? It’ll
   feel weird, do it anyway)
 


### PR DESCRIPTION
It's nice to see the results of the code you helped write, because it helps give a sense of accomplishment, you can review it for more learning or practice, or you can look for errors. But sometimes you're pairing on a private repository that only one of you has access to, so those results aren't automatically available. By explicitly sharing them, we can have something extra to brag about and learn from.