### PR TITLE
Removed IgnoredMethods

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -97,7 +97,6 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   CountComments: true  # count full line comments?
   Max: 25
-  IgnoredMethods: []
   Exclude:
     - "spec/**/*"
 


### PR DESCRIPTION
Removed `IgnoredMethods` parameter from `Metrics/BlockLength` cop for two reasons:

1) Its value is the same as the default `[]`. 
2) In newer versions of rubocop, IgnoredMethods is marked as deprecated (see [rubocop/rubocop#10829](https://github.com/rubocop/rubocop/pull/10829)) and AllowedMethods should be used. Since `AllowedMethods` default is also [] I think we don't need it in this guide. 