### PR TITLE
Fix broken thoughtbot logo on README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ waiting a week for everybody to leave feedback**.
 Thank you,
 [contributors](https://github.com/thoughtbot/guides/graphs/contributors)!
 
-![thoughtbot](http://presskit.thoughtbot.com/images/thoughtbot-logo-for-readmes.svg)
+![thoughtbot](https://thoughtbot.com/brand_assets/93:44.svg)
 
 Guides is maintained by [thoughtbot, inc](https://thoughtbot.com).
 


### PR DESCRIPTION
The previous thoughtbot logo link is broken. Replace it with another link used on other thoughtbot repositories.  


Before:
![Screenshot 2023-04-05 at 10 16 44](https://user-images.githubusercontent.com/14362964/230092064-0e43ef7c-754c-40ad-b902-e83b039120cd.png)

Now:
![Screenshot 2023-04-05 at 10 16 30](https://user-images.githubusercontent.com/14362964/230092323-ff54c9f7-d304-4d9c-a3d6-cb878e0a3d31.png)

