### PR TITLE
Fix broken links in Ruby and Rails guides

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -58,7 +58,7 @@
 [`.ruby-version`]: https://gist.github.com/fnichol/1912050
 [redirects]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30
 [spring binstubs]: https://github.com/sstephenson/rbenv/wiki/Understanding-binstubs
-[prevent tampering]: http://blog.bigbinary.com/2013/03/19/cookies-on-rails.html
+[prevent tampering]: https://www.bigbinary.com/blog/cookies-on-rails
 [`app/views/application`]: http://railscasts.com/episodes/269-template-inheritance
 
 ## Migrations

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -94,8 +94,8 @@
 
 [http api design guide]: https://github.com/interagent/http-api-design
 [oj]: https://github.com/ohler55/oj
-[system specs]: https://relishapp.com/rspec/rspec-rails/docs/system-specs/system-spec
-[request specs]: https://www.relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec
+[system specs]: https://web.archive.org/web/20230131005307/https://relishapp.com/rspec/rspec-rails/docs/system-specs/system-spec
+[request specs]: https://web.archive.org/web/20221207001104/https://www.relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec
 
 ## How to...
 


### PR DESCRIPTION
Several links in Ruby and Rails guides are broken. Replacing them with working ones pointing to the same information.