### PR TITLE
Add 2 new examples to remote-meeting guidelines.

### DIFF
--- a/working-together/README.md
+++ b/working-together/README.md
@@ -183,12 +183,14 @@ We've compiled some guidelines from various sources to help people feel included
   - Be mindful of those dialing in by phone, as they might not have access to certain software features (e.g. hand raising).
 
 - **Meeting Recordings**
-  - Before recording a meeting let everyone know you are planning to record the meeting and only do so once you have consent from all participants.
+  - Indicate ahead of time that the meeting or portions of the meeting will be recorded. This gives others the opportunity not to attend. 
+  - Only record the meeting once you have consent from all participants.
   - Let people know when the recording has started and when it has finished.
 
 - **Audio Transcriptions**
   - Some people may want to use meeting transcription software to transcribe and summarize online meetings.
   - Before activating the transcription software let everyone know you are planning to use the transcription software for the meeting and only do so once you have consent from all participants.
+  - Some people may not be comfortable with the transcription software because data will be sent to a third-party service.
   - Let people know when the transription has started and when it has finished.
 
 

--- a/working-together/README.md
+++ b/working-together/README.md
@@ -182,6 +182,15 @@ We've compiled some guidelines from various sources to help people feel included
   - Use the chat for questions and have someone monitor the chat to make sure all questions are addressed.
   - Be mindful of those dialing in by phone, as they might not have access to certain software features (e.g. hand raising).
 
+- **Meeting Recordings**
+  - Before recording a meeting let everyone know you are planning to record the meeting and only do so once you have consent from all participants.
+  - Let people know when the recording has started and when it has finished.
+
+- **Audio Transcriptions**
+  - Some people may want to use meeting transcription software to transcribe and summarize online meetings.
+  - Before activating the transcription software let everyone know you are planning to use the transcription software for the meeting and only do so once you have consent from all participants.
+  - Let people know when the transription has started and when it has finished.
+
 
 Guidelines adapted from [Paradigm](https://www.paradigmiq.com/)'s Remote Inclusion Checklist
 


### PR DESCRIPTION
This PR adds 2 new examples to the remote-meeting guidelines.

---

The first example "Meeting Recordings" addresses a common scenario where people want to record a meeting so they themselves can refer back to it or someone who is not present can view it later.

Some video-call software will actively tell you when a meeting is being recorded and seek your permission, others will not. Moreover, someone may be focusing on a different screen.

Therefore, it would be helpful for the person recording the meeting to verbally achieve consensus before recording. 

This will ensure everyone is aware and people can choose to opt out of the meeting or turn their camera off.

---

The second example "Audio Transcriptions" is becoming more popular with the advances in AI. There are many 3rd party apps or software which provide this functionality and it can be very useful in many circumstances. 

As an example, for someone with auditory processing challenges, this can allow them to read and even summarize the meeting at a later point in time. Transcriptions can also negate the need for a meeting note-taker.

However, we also need to be sensitive to audio being captured by 3rd party apps. People may not want their words being recorded and stored elsewhere.

Given this, I think it makes sense to let others know if you are using a transcription app so people are aware that what they are saying is being recorded.