### PR TITLE
Remove Black - Python formatter

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,5 @@
 # Python
 
 - Follow [PEP 8].
-- Format code using [Black].
 
 [pep 8]: http://www.python.org/dev/peps/pep-0008/
-[Black]: https://github.com/psf/black


### PR DESCRIPTION
We don't write a lot of Python, and when we do we don't use Black. This isn't an ideological or philosphical stance, but simply the reality of the situation.

When we do write Python, it is typically integrated with an existing client team, where we use their tooling and preferences. Lately it's been in partnership with data scientists.

This reverts commit 27f324d6d80f5d21e4b65374f20676551c429ae5 (#689).