### PR TITLE
fix: Update links to 'thoughtbot.com/blog'

### DIFF
--- a/angular/README.md
+++ b/angular/README.md
@@ -9,6 +9,6 @@
   reasons].
 - Don't use the `jQuery` or `$` global. Access jQuery via `angular.element`.
 
-[avoid manual dependency annotations]: http://robots.thoughtbot.com/avoid-angularjs-dependency-annotation-with-rails
+[avoid manual dependency annotations]: http://thoughtbot.com/blog/avoid-angularjs-dependency-annotation-with-rails
 [ngannotate]: https://github.com/kikonen/ngannotate-rails
 [performance reasons]: https://github.com/angular-translate/angular-translate/wiki/Getting-Started#using-translate-directive

--- a/email/README.md
+++ b/email/README.md
@@ -6,7 +6,7 @@
   mailer view before merging. Use [MailView] gem unless using Rails version
   4.1.0 or later.
 
-[amazon ses]: http://robots.thoughtbot.com/post/3105121049/delivering-email-with-amazon-ses-in-a-rails-3-app
+[amazon ses]: https://thoughtbot.com/blog/deliver-email-with-amazon-ses-in-a-rails-app
 [sendgrid]: https://devcenter.heroku.com/articles/sendgrid
 [mailview]: https://github.com/37signals/mail_view
 [actionmailer preview]: http://api.rubyonrails.org/v4.1.0/classes/ActionMailer/Base.html#class-ActionMailer::Base-label-Previewing+emails

--- a/object-oriented-design/README.md
+++ b/object-oriented-design/README.md
@@ -10,4 +10,4 @@
   exceeds 100 lines, it may be doing too many things.
 - [Tell, don't ask].
 
-[tell, don't ask]: https://robots.thoughtbot.com/tell-dont-ask
+[tell, don't ask]: https://thoughtbot.com/blog/tell-dont-ask

--- a/rails/README.md
+++ b/rails/README.md
@@ -75,7 +75,7 @@
 - [Add foreign key constraints] in migrations.
 
 [`on_delete` behavior for foreign keys]: http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_foreign_key
-[add foreign key constraints]: http://robots.thoughtbot.com/referential-integrity-with-foreign-keys
+[add foreign key constraints]: http://thoughtbot.com/blog/referential-integrity-with-foreign-keys
 
 ## Routes
 
@@ -99,7 +99,7 @@
 - Use the user's name in the `From` header and email in the `Reply-To` when
   [delivering email on behalf of the app's users].
 
-[delivering email on behalf of the app's users]: http://robots.thoughtbot.com/post/3215611590/recipe-delivering-email-on-behalf-of-users
+[delivering email on behalf of the app's users]: http://thoughtbot.com/blog/post/delivering-email-on-behalf-of-users
 
 ## Code Review
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -67,9 +67,9 @@
 - Use an [exact version] in the `Gemfile` for fragile gems, such as Rails.
 
 [ruby version]: http://bundler.io/v1.3/gemfile_ruby.html
-[exact version]: http://robots.thoughtbot.com/post/35717411108/a-healthy-bundle
-[pessimistic version]: http://robots.thoughtbot.com/post/35717411108/a-healthy-bundle
-[versionless]: http://robots.thoughtbot.com/post/35717411108/a-healthy-bundle
+[exact version]: http://thoughtbot.com/blog/a-healthy-bundle
+[pessimistic version]: http://thoughtbot.com/blog/a-healthy-bundle
+[versionless]: http://thoughtbot.com/blog/a-healthy-bundle
 
 ## Ruby Gems
 

--- a/testing-rspec/README.md
+++ b/testing-rspec/README.md
@@ -36,9 +36,9 @@
 [`allow` syntax]: https://github.com/rspec/rspec-mocks#method-stubs
 [dependency injection]: http://en.wikipedia.org/wiki/Dependency_injection
 [`delayed::job` matcher]: https://gist.github.com/3186463
-[stubs and spies]: http://robots.thoughtbot.com/post/159805295/spy-vs-spy
+[stubs and spies]: http://thoughtbot.com/blog/spy-vs-spy
 [assertions about state]: https://speakerdeck.com/skmetz/magic-tricks-of-testing-railsconf?slide=51
-[fake]: http://robots.thoughtbot.com/post/219216005/fake-it
+[fake]: http://thoughtbot.com/blog/fake-it
 [sut]: http://xunitpatterns.com/SUT.html
 
 ## Acceptance Tests


### PR DESCRIPTION
In this commit we're updating the links from `robots.thoughtbot.com` to `thoughtbot.com/blog`.

There were also some links that had a slighty different path, so we updated those as well.