### PR TITLE
Call dynamic-readme reusable workflow

### DIFF
--- a/.github/worfklows/dynamic-readme.yml
+++ b/.github/worfklows/dynamic-readme.yml
@@ -1,0 +1,17 @@
+name: update-templates
+
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-templates:
+    permissions:
+      contents: write
+      pull-requests: write
+      pages: write
+    uses: thoughtbot/templates/.github/workflows/dynamic-readme.yaml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -98,13 +98,10 @@ waiting a week for everybody to leave feedback**.
 Thank you,
 [contributors](https://github.com/thoughtbot/guides/graphs/contributors)!
 
-![thoughtbot](https://thoughtbot.com/brand_assets/93:44.svg)
-
-Guides is maintained by [thoughtbot, inc](https://thoughtbot.com).
-
 ## License
 
-Guides is © 2020 thoughtbot, inc. It is distributed under the [Creative Commons
+Guides is © 2020-2024 thoughtbot, inc. It is distributed under the [Creative Commons
 Attribution License](http://creativecommons.org/licenses/by/3.0/).
 
-The names and logos for thoughtbot are trademarks of thoughtbot, inc.
+<!-- START /templates/footer.md -->
+<!-- END /templates/footer.md -->


### PR DESCRIPTION
We want to have a way to edit our README footer at one place and have the changes from there be propagated to our repos.

By adding this snippet in the README, we call this reusable workflow: https://github.com/thoughtbot/templates/blob/main/.github/workflows/dynamic-readme.yaml that renders and updates the README footer dynamically.