### PR TITLE
Translations as a default for client projects

### DIFF
--- a/accessibility/README.md
+++ b/accessibility/README.md
@@ -126,13 +126,6 @@ assign it one of four ratings:
 Use the Notes sheet to leave per-cell comments when necessary, referencing them
 with a link. The next steps for an audit are handled on a per-project basis.
 
-## Translations
-
-- Ensure that the application is setup to support multiple locales.
-- Ensure that the application raises an error when a translation is missing for a
-  given locale in development.
-
-
 [accessibility audit template]: https://www.fsb.org.uk/resources-page/accessibility-audit-template.html
 [accesslint]: https://github.com/marketplace/accesslint
 [axe]: https://www.deque.com/axe/axe-for-web/integrations/

--- a/accessibility/README.md
+++ b/accessibility/README.md
@@ -126,6 +126,13 @@ assign it one of four ratings:
 Use the Notes sheet to leave per-cell comments when necessary, referencing them
 with a link. The next steps for an audit are handled on a per-project basis.
 
+## Translations
+
+- Ensure that the application is setup to support multiple locales.
+- Ensure that the application raises an error when a translation is missing for a
+  given locale in development.
+
+
 [accessibility audit template]: https://www.fsb.org.uk/resources-page/accessibility-audit-template.html
 [accesslint]: https://github.com/marketplace/accesslint
 [axe]: https://www.deque.com/axe/axe-for-web/integrations/

--- a/rails/README.md
+++ b/rails/README.md
@@ -55,6 +55,12 @@
   FactoryBot factories.
 - Use `touch: true` when declaring `belongs_to` relationships.
 
+## Translations
+
+- Ensure that the application is setup to support multiple locales.
+- Ensure that the application raises an error when a translation is missing for a
+  given locale in development and tests.
+
 [`.ruby-version`]: https://gist.github.com/fnichol/1912050
 [redirects]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30
 [spring binstubs]: https://github.com/sstephenson/rbenv/wiki/Understanding-binstubs


### PR DESCRIPTION
We would like to enable translations as a default for our clients projects.

For this, we are including guidelines in accessibility about translations.

Related to issue https://github.com/thoughtbot/handbook/issues/3751