### PR TITLE
Remove communication guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ programming in style.
 ### Collaboration
 
 - [Code Review](/code-review/)
-- [Communication](/communication/)
 - [Inclusive Culture](/inclusive-culture/)
 - [Open Source](/open-source/)
 - [Product Review](/product-review/)

--- a/communication/README.md
+++ b/communication/README.md
@@ -1,8 +1,0 @@
-# Communication
-
-A guide for communicating within thoughtbot.
-
-## Tickets
-
-- People assign themselves to tickets. When in doubt, do not assign a ticket to
-  someone.


### PR DESCRIPTION
We're moving non-technical guides over to our Playbook. [The communication guide only had one bullet point and it's already referenced in the planning part of the playbook](https://thoughtbot.com/playbook/planning/manage-priorities-with-a-lightweight-process):

> Once the cards in the Next Up list have been prioritized and vetted, they are ready for design and development. A designer or developer "puts their face on it" by assigning it to themselves and pulling it into the In Progress list.