### PR TITLE
Removed GraphQL recommendation from tech stack guide

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -23,7 +23,6 @@
 [react hooks]: https://reactjs.org/docs/hooks-overview.html
 [custom hooks]: https://reactjs.org/docs/hooks-overview.html#building-your-own-hooks
 [streamich/react-use]: https://github.com/streamich/react-use
-[graphql]: https://graphql.org/
 [function components]: https://reactjs.org/docs/components-and-props.html
 [class components]: https://reactjs.org/docs/react-component.html
 [forward refs]: https://reactjs.org/docs/forwarding-refs.html
@@ -45,13 +44,9 @@
 - For greenfield React projects we like to use [TypeScript]. TypeScript is a
   typed superset of JavaScript that compiles to plain JavaScript. For a quick
   introduction, check out [TypeScript in 5 minutes].
-- If our app needs to make network requests and hold state outside of a
-  component, we like using GraphQL and our preferred library is [Apollo]. We
-  have a [section on `GraphQL`](/graphql) in our Guides.
 - When building React apps with TypeScript and Apollo, we've found working in
   [VSCode] to be a mostly-good experience.
 
 [typescript]: https://www.typescriptlang.org/
 [typescript in 5 minutes]: https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html
-[apollo]: https://www.apollographql.com
 [vscode]: https://code.visualstudio.com/

--- a/tech-stack/README.md
+++ b/tech-stack/README.md
@@ -33,10 +33,6 @@ while building applications.
 - When building a cross-platform mobile app that will be delivered via an app
   store, use React Native.
 
-### API
-
-- Use GraphQL as an API layer when connecting a mobile app to a web service.
-
 ### Web
 
 - Use Ruby on Rails for new applications.


### PR DESCRIPTION
Not everyone at thoughtbot is convinced that GraphQL is the right choice for building APIs. It has complexity and footguns.

By removing this recommendation, we leave it open to a developer's best judgement.