### PR TITLE
Require schemas for APIs

### DIFF
--- a/tech-stack/README.md
+++ b/tech-stack/README.md
@@ -36,6 +36,7 @@ while building applications.
 ### API
 
 - Use GraphQL as an API layer when connecting a mobile app to a web service.
+- Use a schema to describe the shape of the inputs and outputs of an API endpoint.
 
 ### Web
 


### PR DESCRIPTION
When consuming an API from a client, a schema makes your life easier. Not only does it provide documentation, but it also can integrate into automated tooling such as type-checkers and code generators.

On the back end, it's nice to plug a schema into a unit test to guarantee that the implementation matches the spec. Depending on the system you use, schemas can also be used to generate API docs or test fixtures.