### PR TITLE
Rails: Update guidance on development environment seed data.

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -79,7 +79,7 @@ Guidance on ActiveRecord, ActiveModel, and other model objects.
   suffixes.
 - Keep `db/schema.rb` or `db/development_structure.sql` under version control.
 - Use `db/seeds.rb` for data that is required in all environments.
-- Use `dev:prime` rake task for development environment seed data.
+- Use `development:db:seed` rake task for development environment seed data.
 
 ## Migrations
 

--- a/rails/README.md
+++ b/rails/README.md
@@ -79,7 +79,7 @@ Guidance on ActiveRecord, ActiveModel, and other model objects.
   suffixes.
 - Keep `db/schema.rb` or `db/development_structure.sql` under version control.
 - Use `db/seeds.rb` for data that is required in all environments.
-- Use `development:db:seed` rake task for development environment seed data.
+- Use `development:db:seed` rake task for development environment seed data. [Example](/rails/how-to/seed-data.md).
 
 ## Migrations
 

--- a/rails/how-to/seed-data.md
+++ b/rails/how-to/seed-data.md
@@ -1,0 +1,45 @@
+# How to seed development data
+
+```ruby
+# lib/development/seeder.rb
+
+require "factory_bot"
+
+module Development
+  class Seeder
+    include FactoryBot::Syntax::Methods
+
+    def self.load_seeds
+      new.load_seeds
+    end
+
+    def load_seeds
+      emails = %w[ralph@example.com ruby@example.com]
+
+      emails.each do |email|
+        create(:user, email:, password: "password") unless User.exists?(email:)
+      end
+    end
+  end
+end
+```
+
+```rb
+# lib/tasks/development.rake
+
+abort "Seeds can only be loaded in local environments" unless Rails.env.local?
+
+namespace :development do
+  namespace :db do
+    desc "Loads seed data into development."
+    task seed: :environment do
+      Development::Seeder.load_seeds
+    end
+
+    namespace :seed do
+      desc "Truncate tables of each database for development and loads seed data."
+      task replant: [ "environment", "db:truncate_all", "development:db:seed" ]
+    end
+  end
+end
+```


### PR DESCRIPTION
Relates to [this proposal][1] for Suspenders.

> We have relied on [`dev:prime`][2] for loading data necessary for users
to view most of the features of the app in development.
>
> However, there were a few areas of improvement.
>
> First, rename `dev` namespace to `development`, and rename
[`prime`][1] task to `seed` for improved clarity.
>
> The, introduces `development:seed:replant` take to create parity with
the existing `db:seed:replant` task.

We're already doing this in ChatBot.

https://github.com/thoughtbot/chat_bot/pull/52

[1]: https://github.com/thoughtbot/suspenders/pull/1251
[2]: https://thoughtbot.com/blog/priming-the-pump
