### PR TITLE
Use an opinionated set of rules for Rubocop

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -2,7 +2,8 @@
 
 [Sample 1](sample_1.rb) [Sample 2](sample_2.rb)
 
-- Use [standard]
+- Use an opinionated set of rules for Rubocop. Prefer [standard] for new projects.
+  - Having an already decided configuration removes bikeshedding on what a Rubocop configuration should be.
 - Avoid conditional modifiers (lines that end with conditionals). [36491dbb9]
 - Avoid multiple assignments per line (`one, two = 1, 2`). [#109]
 - Avoid organizational comments (`# Validations`). [#63]


### PR DESCRIPTION
Most projects that thoughtbot is working on currently did not start here. The "Use standard" recommendation comes from a time that that wasn't true.

There are a few reasons not to use Standard in existing projects:
- A large project does not already use Standard and retrofitting would be costly
- Need or want Rubocop rules other than Standard's opinionated set