### PR TITLE
Rails: Prefer timestamps over boolean

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -3,7 +3,7 @@
 - Use private instead of protected when defining controller methods.
 - Name date columns with `_on` suffixes.
 - Name datetime columns with `_at` suffixes.
-- Back boolean concepts like deleted?, published?, or active? with timestamps columns in the database `deleted_at`, `published_at`, `active_at`.
+- Back boolean concepts like deleted? or published? with timestamps columns in the database `deleted_at`, `published_at`.
   This can be valuable when you need to know **when** something took place. [Time for A Boolean](https://github.com/calebhearth/time_for_a_boolean) provides a nice interface for this.
 - Name time columns (referring to a time of day with no date) with `_time`
   suffixes.

--- a/rails/README.md
+++ b/rails/README.md
@@ -3,6 +3,8 @@
 - Use private instead of protected when defining controller methods.
 - Name date columns with `_on` suffixes.
 - Name datetime columns with `_at` suffixes.
+- Back boolean concepts like deleted?, published?, or active? with timestamps
+  via [Time for A Boolean](https://github.com/calebhearth/time_for_a_boolean)
 - Name time columns (referring to a time of day with no date) with `_time`
   suffixes.
 - Name initializers for their gem name.

--- a/rails/README.md
+++ b/rails/README.md
@@ -3,8 +3,8 @@
 - Use private instead of protected when defining controller methods.
 - Name date columns with `_on` suffixes.
 - Name datetime columns with `_at` suffixes.
-- Back boolean concepts like deleted?, published?, or active? with timestamps
-  via [Time for A Boolean](https://github.com/calebhearth/time_for_a_boolean)
+- Back boolean concepts like deleted?, published?, or active? with timestamps.
+  This can be valuable when you need to know **when** something took place. [Time for A Boolean](https://github.com/calebhearth/time_for_a_boolean) provides a nice interface for this.
 - Name time columns (referring to a time of day with no date) with `_time`
   suffixes.
 - Name initializers for their gem name.

--- a/rails/README.md
+++ b/rails/README.md
@@ -3,7 +3,7 @@
 - Use private instead of protected when defining controller methods.
 - Name date columns with `_on` suffixes.
 - Name datetime columns with `_at` suffixes.
-- Back boolean concepts like deleted?, published?, or active? with timestamps.
+- Back boolean concepts like deleted?, published?, or active? with timestamps columns in the database `deleted_at`, `published_at`, `active_at`.
   This can be valuable when you need to know **when** something took place. [Time for A Boolean](https://github.com/calebhearth/time_for_a_boolean) provides a nice interface for this.
 - Name time columns (referring to a time of day with no date) with `_time`
   suffixes.


### PR DESCRIPTION
I've used this on several client and personal projects, and find it
valuable.

This isn't to say everything that is a boolean should be a timestamp, but
I think it's worth highlighting.
