### PR TITLE
Rails: Remove outdated guidance on background jobs

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -97,12 +97,6 @@
 [resource routing]: https://guides.rubyonrails.org/routing.html#resource-routing-the-rails-default
 [generating routes]: https://guides.rubyonrails.org/routing.html#generating-paths-and-urls-from-code
 
-## Background Jobs
-
-- Define a `PRIORITY` constant at the top of delayed job classes.
-- Define two public methods: `self.enqueue` and `perform`.
-- Put delayed job classes in `app/jobs`.
-
 ## Email
 
 - Use the user's name in the `From` header and email in the `Reply-To` when


### PR DESCRIPTION
This guidance was introduced [13 years ago][sha]!

A lot has changed since then, and I don't think this reflects our
current preferences.

There's an [opportunity][] to discuss what our new preferences are, but
for now, I think removing this is better than keeping it.

[sha]: https://github.com/thoughtbot/guides/commit/19f450f5841a0bbc736abab3e40e2144a42769c9
[opportunity]: https://github.com/thoughtbot/suspenders/issues/1210
