### PR TITLE
Add Markdown Linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,4 +8,4 @@ jobs:
     - uses: DavidAnson/markdownlint-cli2-action@v19
       with:
         globs: |
-          *.md
+          ./**/*.md

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,11 @@
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: DavidAnson/markdownlint-cli2-action@v19
+      with:
+        globs: |
+          *.md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: update-templates
 
-on: 
+on:
   push:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.obsidian
+
+node_modules

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -115,9 +115,8 @@
     /* MD040 - Fenced code blocks should have a language specified */
     "fenced-code-language": true,
 
-    // FIXME: enable and configure
     /* MD041 - First line in a file should be a top-level heading */
-    "first-line-heading": false,
+    "first-line-heading": true,
 
     /* MD042 - No empty links */
     "no-empty-links": true,

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -24,9 +24,8 @@
     /* MD009 - Trailing spaces */
     "no-trailing-spaces": true,
 
-    // FIXME: enable and configure?
     /* MD010 - Hard tabs */
-    "no-hard-tabs": false,
+    "no-hard-tabs": true,
 
     /* MD011 - Reversed link syntax */
     "no-reversed-links": true,

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,5 +1,7 @@
 {
-  // See: https://github.com/DavidAnson/markdownlint/blob/v0.32.1/README.md#rules--aliases
+  // https://github.com/DavidAnson/markdownlint/blob/v0.32.1/README.md#rules--aliases
+  // https://github.com/DavidAnson/markdownlint-cli2/blob/main/test/markdownlint-cli2-jsonc-example/.markdownlint-cli2.jsonc
+  // https://github.com/DavidAnson/markdownlint-cli2/blob/main/schema/markdownlint-config-schema.json
   "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/refs/heads/main/schema/markdownlint-cli2-config-schema.json",
   "gitignore": true,
   "config": {

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -11,7 +11,6 @@
     /* MD003 - Heading style */
     "heading-style": true,
 
-    // FIXME: enable and configure?
     /* MD004 - Unordered list style */
     "ul-style": true,
 
@@ -22,9 +21,8 @@
     "ul-indent": true,
     // { "indent": 2, "start_indented": false },
 
-    // FIXME: enable and configure?
     /* MD009 - Trailing spaces */
-    "no-trailing-spaces": false,
+    "no-trailing-spaces": true,
 
     // FIXME: enable and configure?
     /* MD010 - Hard tabs */

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -3,152 +3,167 @@
   "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/refs/heads/main/schema/markdownlint-cli2-config-schema.json",
   "gitignore": true,
   "config": {
-    /* MD001 - Heading levels should only increment by one level at a time */ 
-    "heading-increment": false,
+    /* MD001 - Heading levels should only increment by one level at a time */
+    "heading-increment": true,
 
-    /* MD003 - Heading style */ 
-    "heading-style": false,
-    // { "style": "atx" },
+    /* MD003 - Heading style */
+    "heading-style": true,
 
-    /* MD004 - Unordered list style */ 
+    // FIXME: enable and configure?
+    /* MD004 - Unordered list style */
     "ul-style": false,
 
-    /* MD005 - Inconsistent indentation for list items at the same level */ 
-    "list-indent": false,
+    /* MD005 - Inconsistent indentation for list items at the same level */
+    "list-indent": true,
 
-    /* MD007 - Unordered list indentation */ 
-    "ul-indent": false,
+    /* MD007 - Unordered list indentation */
+    "ul-indent": true,
     // { "indent": 2, "start_indented": false },
-    
-    /* MD009 - Trailing spaces */ 
+
+    // FIXME: enable and configure?
+    /* MD009 - Trailing spaces */
     "no-trailing-spaces": false,
 
-    /* MD010 - Hard tabs */ 
+    // FIXME: enable and configure?
+    /* MD010 - Hard tabs */
     "no-hard-tabs": false,
 
-    /* MD011 - Reversed link syntax */ 
-    "no-reversed-links": false,
+    /* MD011 - Reversed link syntax */
+    "no-reversed-links": true,
 
-    /* MD012 - Multiple consecutive blank lines */ 
+    // FIXME: enable and configure?
+    /* MD012 - Multiple consecutive blank lines */
     "no-multiple-blanks": false,
 
-    /* MD013 - Line length */ 
+    // FIXME: enable and configure?
+    /* MD013 - Line length */
     // NOTE: Unable to disable this without some files being caught still
     "line-length": false,
 
-    /* MD014 - Dollar signs used before commands without showing output */ 
+    // FIXME: enable and configure?
+    /* MD014 - Dollar signs used before commands without showing output */
     "commands-show-output": false,
 
-    /* MD018 - No space after hash on atx style heading */ 
-    "no-missing-space-atx": false,
+    /* MD018 - No space after hash on atx style heading */
+    "no-missing-space-atx": true,
 
 
-    /* MD019 - Multiple spaces after hash on atx style heading */ 
-    "no-multiple-space-atx": false,
+    /* MD019 - Multiple spaces after hash on atx style heading */
+    "no-multiple-space-atx": true,
 
-    /* MD020 - No space inside hashes on closed atx style heading */ 
-    "no-missing-space-closed-atx": false,
+    /* MD020 - No space inside hashes on closed atx style heading */
+    "no-missing-space-closed-atx": true,
 
-    /* MD021 - Multiple spaces inside hashes on closed atx style heading */ 
-    "no-multiple-space-closed-atx": false,
+    /* MD021 - Multiple spaces inside hashes on closed atx style heading */
+    "no-multiple-space-closed-atx": true,
 
-    /* MD022 - Headings should be surrounded by blank lines */ 
+    // FIXME: enable and configure
+    /* MD022 - Headings should be surrounded by blank lines */
     "blanks-around-headings": false,
 
-    /* MD023 - Headings must start at the beginning of the line */ 
-    "heading-start-left": false,
+    /* MD023 - Headings must start at the beginning of the line */
+    "heading-start-left": true,
 
-    /* MD024 - Multiple headings with the same content */ 
+    // FIXME: enable and configure
+    /* MD024 - Multiple headings with the same content */
     "no-duplicate-heading": false,
 
-    /* MD025 - Multiple top-level headings in the same document */ 
-    "single-title": false,
+    /* MD025 - Multiple top-level headings in the same document */
+    "single-title": true,
 
-    /* MD026 - Trailing punctuation in heading */ 
+    // FIXME: enable and configure
+    /* MD026 - Trailing punctuation in heading */
     "no-trailing-punctuation": false,
 
-    /* MD027 - Multiple spaces after blockquote symbol */ 
-    "no-multiple-space-blockquote": false,
+    /* MD027 - Multiple spaces after blockquote symbol */
+    "no-multiple-space-blockquote": true,
 
-    /* MD028 - Blank line inside blockquote */ 
-    "no-blanks-blockquote": false,
+    /* MD028 - Blank line inside blockquote */
+    "no-blanks-blockquote": true,
 
-    /* MD029 - Ordered list item prefix */ 
-    "ol-prefix": false,
+    /* MD029 - Ordered list item prefix */
+    "ol-prefix": true,
 
-    /* MD030 - Spaces after list markers */ 
-    "list-marker-space": false,
+    /* MD030 - Spaces after list markers */
+    "list-marker-space": true,
 
-    /* MD031 - Fenced code blocks should be surrounded by blank lines */ 
-    "blanks-around-fences": false,
+    /* MD031 - Fenced code blocks should be surrounded by blank lines */
+    "blanks-around-fences": true,
 
-    /* MD032 - Lists should be surrounded by blank lines */ 
-    "blanks-around-lists": false,
+    /* MD032 - Lists should be surrounded by blank lines */
+    "blanks-around-lists": true,
 
-    /* MD033 - Inline HTML */ 
+    // FIXME: enable and configure
+    /* MD033 - Inline HTML */
     "no-inline-html": false,
 
-    /* MD034 - Bare URL used */ 
+    // FIXME: enable and configure
+    /* MD034 - Bare URL used */
     "no-bare-urls": false,
 
-    /* MD035 - Horizontal rule style */ 
-    "hr-style": false,
+    /* MD035 - Horizontal rule style */
+    "hr-style": true,
 
-    /* MD036 - Emphasis used instead of a heading */ 
-    "no-emphasis-as-heading": false,
+    /* MD036 - Emphasis used instead of a heading */
+    "no-emphasis-as-heading": true,
 
-    /* MD037 - Spaces inside emphasis markers */ 
-    "no-space-in-emphasis": false,
+    /* MD037 - Spaces inside emphasis markers */
+    "no-space-in-emphasis": true,
 
-    /* MD038 - Spaces inside code span elements */ 
-    "no-space-in-code": false,
+    /* MD038 - Spaces inside code span elements */
+    "no-space-in-code": true,
 
-    /* MD039 - Spaces inside link text */ 
-    "no-space-in-links": false,
+    /* MD039 - Spaces inside link text */
+    "no-space-in-links": true,
 
-    /* MD040 - Fenced code blocks should have a language specified */ 
+    // FIXME: enable and configure
+    /* MD040 - Fenced code blocks should have a language specified */
     "fenced-code-language": false,
 
-    /* MD041 - First line in a file should be a top-level heading */ 
+    // FIXME: enable and configure
+    /* MD041 - First line in a file should be a top-level heading */
     "first-line-heading": false,
 
-    /* MD042 - No empty links */ 
-    "no-empty-links": false,
+    /* MD042 - No empty links */
+    "no-empty-links": true,
 
-    /* MD043 - Required heading structure */ 
-    "required-headings": false,
+    /* MD043 - Required heading structure */
+    "required-headings": true,
 
-    /* MD044 - Proper names should have the correct capitalization */ 
-    "proper-names": false,
+    /* MD044 - Proper names should have the correct capitalization */
+    "proper-names": true,
 
-    /* MD045 - Images should have alternate text (alt text) */ 
-    "no-alt-text": false,
+    /* MD045 - Images should have alternate text (alt text) */
+    "no-alt-text": true,
 
-    /* MD046 - Code block style */ 
+    // FIXME: enable and configure
+    /* MD046 - Code block style */
     "code-block-style": false,
 
-    /* MD047 - Files should end with a single newline character */ 
+    // FIXME: enable and configure
+    /* MD047 - Files should end with a single newline character */
     "single-trailing-newline": false,
 
-    /* MD048 - Code fence style */ 
-    "code-fence-style": false,
+    /* MD048 - Code fence style */
+    "code-fence-style": true,
 
-    /* MD049 - Emphasis style */ 
-    "emphasis-style": false,
+    /* MD049 - Emphasis style */
+    "emphasis-style": true,
 
-    /* MD050 - Strong style */ 
-    "strong-style": false,
+    /* MD050 - Strong style */
+    "strong-style": true,
 
-    /* MD051 - Link fragments should be valid */ 
-    "link-fragments": false,
+    /* MD051 - Link fragments should be valid */
+    "link-fragments": true,
 
-    /* MD052 - Reference links and images should use a label that is defined */ 
-    "reference-links-images": false,
+    /* MD052 - Reference links and images should use a label that is defined */
+    "reference-links-images": true,
 
-    /* MD053 - Link and image reference definitions should be needed */ 
+    // FIXME: enable and configure
+    /* MD053 - Link and image reference definitions should be needed */
     "link-image-reference-definitions": false,
 
-    /* MD054 - Link and image style */ 
-    "link-image-style": false
+    /* MD054 - Link and image style */
+    "link-image-style": true
   }
 }

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -30,9 +30,8 @@
     /* MD011 - Reversed link syntax */
     "no-reversed-links": true,
 
-    // FIXME: enable and configure?
     /* MD012 - Multiple consecutive blank lines */
-    "no-multiple-blanks": false,
+    "no-multiple-blanks": true,
 
     // FIXME: enable and configure?
     /* MD013 - Line length */

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -89,9 +89,10 @@
     /* MD032 - Lists should be surrounded by blank lines */
     "blanks-around-lists": true,
 
-    // FIXME: enable and configure
     /* MD033 - Inline HTML */
-    "no-inline-html": false,
+    "no-inline-html": {
+      "allowed_elements": ["dl", "dt", "dd", "kbd", "details"]
+    },
 
     // FIXME: enable and configure
     /* MD034 - Bare URL used */

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -13,7 +13,7 @@
 
     // FIXME: enable and configure?
     /* MD004 - Unordered list style */
-    "ul-style": false,
+    "ul-style": true,
 
     /* MD005 - Inconsistent indentation for list items at the same level */
     "list-indent": true,

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -60,14 +60,14 @@
     /* MD023 - Headings must start at the beginning of the line */
     "heading-start-left": true,
 
-    // FIXME: enable and configure
     /* MD024 - Multiple headings with the same content */
-    "no-duplicate-heading": false,
+    "no-duplicate-heading": {
+      "siblings_only": true
+    },
 
     /* MD025 - Multiple top-level headings in the same document */
     "single-title": true,
 
-    // FIXME: enable and configure
     /* MD026 - Trailing punctuation in heading */
     "no-trailing-punctuation": true,
 

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -69,7 +69,7 @@
 
     // FIXME: enable and configure
     /* MD026 - Trailing punctuation in heading */
-    "no-trailing-punctuation": false,
+    "no-trailing-punctuation": true,
 
     /* MD027 - Multiple spaces after blockquote symbol */
     "no-multiple-space-blockquote": true,

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -40,7 +40,7 @@
 
     // FIXME: enable and configure?
     /* MD014 - Dollar signs used before commands without showing output */
-    "commands-show-output": false,
+    "commands-show-output": true,
 
     /* MD018 - No space after hash on atx style heading */
     "no-missing-space-atx": true,

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -133,9 +133,8 @@
     /* MD046 - Code block style */
     "code-block-style": true,
 
-    // FIXME: enable and configure
     /* MD047 - Files should end with a single newline character */
-    "single-trailing-newline": false,
+    "single-trailing-newline": true,
 
     /* MD048 - Code fence style */
     "code-fence-style": true,
@@ -150,11 +149,12 @@
     "link-fragments": true,
 
     /* MD052 - Reference links and images should use a label that is defined */
-    "reference-links-images": true,
+    "reference-links-images": {
+      "shortcut_syntax": true
+    },
 
-    // FIXME: enable and configure
     /* MD053 - Link and image reference definitions should be needed */
-    "link-image-reference-definitions": false,
+    "link-image-reference-definitions": true,
 
     /* MD054 - Link and image style */
     "link-image-style": true

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -94,9 +94,8 @@
       "allowed_elements": ["dl", "dt", "dd", "kbd", "details"]
     },
 
-    // FIXME: enable and configure
     /* MD034 - Bare URL used */
-    "no-bare-urls": false,
+    "no-bare-urls": true,
 
     /* MD035 - Horizontal rule style */
     "hr-style": true,

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -38,7 +38,6 @@
     // NOTE: Unable to disable this without some files being caught still
     "line-length": false,
 
-    // FIXME: enable and configure?
     /* MD014 - Dollar signs used before commands without showing output */
     "commands-show-output": true,
 
@@ -55,9 +54,8 @@
     /* MD021 - Multiple spaces inside hashes on closed atx style heading */
     "no-multiple-space-closed-atx": true,
 
-    // FIXME: enable and configure
     /* MD022 - Headings should be surrounded by blank lines */
-    "blanks-around-headings": false,
+    "blanks-around-headings": true,
 
     /* MD023 - Headings must start at the beginning of the line */
     "heading-start-left": true,

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -33,9 +33,8 @@
     /* MD012 - Multiple consecutive blank lines */
     "no-multiple-blanks": true,
 
-    // FIXME: enable and configure?
     /* MD013 - Line length */
-    // NOTE: Unable to disable this without some files being caught still
+    // NOTE: Disabled to allow lines of any length; could be enabled in a separate PR after discussion
     "line-length": false,
 
     /* MD014 - Dollar signs used before commands without showing output */

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,154 @@
+{
+  // See: https://github.com/DavidAnson/markdownlint/blob/v0.32.1/README.md#rules--aliases
+  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/refs/heads/main/schema/markdownlint-cli2-config-schema.json",
+  "gitignore": true,
+  "config": {
+    /* MD001 - Heading levels should only increment by one level at a time */ 
+    "heading-increment": false,
+
+    /* MD003 - Heading style */ 
+    "heading-style": false,
+    // { "style": "atx" },
+
+    /* MD004 - Unordered list style */ 
+    "ul-style": false,
+
+    /* MD005 - Inconsistent indentation for list items at the same level */ 
+    "list-indent": false,
+
+    /* MD007 - Unordered list indentation */ 
+    "ul-indent": false,
+    // { "indent": 2, "start_indented": false },
+    
+    /* MD009 - Trailing spaces */ 
+    "no-trailing-spaces": false,
+
+    /* MD010 - Hard tabs */ 
+    "no-hard-tabs": false,
+
+    /* MD011 - Reversed link syntax */ 
+    "no-reversed-links": false,
+
+    /* MD012 - Multiple consecutive blank lines */ 
+    "no-multiple-blanks": false,
+
+    /* MD013 - Line length */ 
+    // NOTE: Unable to disable this without some files being caught still
+    "line-length": false,
+
+    /* MD014 - Dollar signs used before commands without showing output */ 
+    "commands-show-output": false,
+
+    /* MD018 - No space after hash on atx style heading */ 
+    "no-missing-space-atx": false,
+
+
+    /* MD019 - Multiple spaces after hash on atx style heading */ 
+    "no-multiple-space-atx": false,
+
+    /* MD020 - No space inside hashes on closed atx style heading */ 
+    "no-missing-space-closed-atx": false,
+
+    /* MD021 - Multiple spaces inside hashes on closed atx style heading */ 
+    "no-multiple-space-closed-atx": false,
+
+    /* MD022 - Headings should be surrounded by blank lines */ 
+    "blanks-around-headings": false,
+
+    /* MD023 - Headings must start at the beginning of the line */ 
+    "heading-start-left": false,
+
+    /* MD024 - Multiple headings with the same content */ 
+    "no-duplicate-heading": false,
+
+    /* MD025 - Multiple top-level headings in the same document */ 
+    "single-title": false,
+
+    /* MD026 - Trailing punctuation in heading */ 
+    "no-trailing-punctuation": false,
+
+    /* MD027 - Multiple spaces after blockquote symbol */ 
+    "no-multiple-space-blockquote": false,
+
+    /* MD028 - Blank line inside blockquote */ 
+    "no-blanks-blockquote": false,
+
+    /* MD029 - Ordered list item prefix */ 
+    "ol-prefix": false,
+
+    /* MD030 - Spaces after list markers */ 
+    "list-marker-space": false,
+
+    /* MD031 - Fenced code blocks should be surrounded by blank lines */ 
+    "blanks-around-fences": false,
+
+    /* MD032 - Lists should be surrounded by blank lines */ 
+    "blanks-around-lists": false,
+
+    /* MD033 - Inline HTML */ 
+    "no-inline-html": false,
+
+    /* MD034 - Bare URL used */ 
+    "no-bare-urls": false,
+
+    /* MD035 - Horizontal rule style */ 
+    "hr-style": false,
+
+    /* MD036 - Emphasis used instead of a heading */ 
+    "no-emphasis-as-heading": false,
+
+    /* MD037 - Spaces inside emphasis markers */ 
+    "no-space-in-emphasis": false,
+
+    /* MD038 - Spaces inside code span elements */ 
+    "no-space-in-code": false,
+
+    /* MD039 - Spaces inside link text */ 
+    "no-space-in-links": false,
+
+    /* MD040 - Fenced code blocks should have a language specified */ 
+    "fenced-code-language": false,
+
+    /* MD041 - First line in a file should be a top-level heading */ 
+    "first-line-heading": false,
+
+    /* MD042 - No empty links */ 
+    "no-empty-links": false,
+
+    /* MD043 - Required heading structure */ 
+    "required-headings": false,
+
+    /* MD044 - Proper names should have the correct capitalization */ 
+    "proper-names": false,
+
+    /* MD045 - Images should have alternate text (alt text) */ 
+    "no-alt-text": false,
+
+    /* MD046 - Code block style */ 
+    "code-block-style": false,
+
+    /* MD047 - Files should end with a single newline character */ 
+    "single-trailing-newline": false,
+
+    /* MD048 - Code fence style */ 
+    "code-fence-style": false,
+
+    /* MD049 - Emphasis style */ 
+    "emphasis-style": false,
+
+    /* MD050 - Strong style */ 
+    "strong-style": false,
+
+    /* MD051 - Link fragments should be valid */ 
+    "link-fragments": false,
+
+    /* MD052 - Reference links and images should use a label that is defined */ 
+    "reference-links-images": false,
+
+    /* MD053 - Link and image reference definitions should be needed */ 
+    "link-image-reference-definitions": false,
+
+    /* MD054 - Link and image style */ 
+    "link-image-style": false
+  }
+}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -112,9 +112,8 @@
     /* MD039 - Spaces inside link text */
     "no-space-in-links": true,
 
-    // FIXME: enable and configure
     /* MD040 - Fenced code blocks should have a language specified */
-    "fenced-code-language": false,
+    "fenced-code-language": true,
 
     // FIXME: enable and configure
     /* MD041 - First line in a file should be a top-level heading */

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -130,9 +130,8 @@
     /* MD045 - Images should have alternate text (alt text) */
     "no-alt-text": true,
 
-    // FIXME: enable and configure
     /* MD046 - Code block style */
-    "code-block-style": false,
+    "code-block-style": true,
 
     // FIXME: enable and configure
     /* MD047 - Files should end with a single newline character */

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+node latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ to abide by the [thoughtbot Code Of Conduct].
 
 We expect everyone to follow the code of conduct anywhere in thoughtbot's
 project codebases, issue trackers, chatrooms, mailing lists, meetups, at other events, and in-person.
-Violators will be warned by the core team. 
+Violators will be warned by the core team.
 Repeat violations will result in being blocked or banned by the core team at or before the 3rd violation.
 
 [thoughtbot code of conduct]: https://thoughtbot.com/open-source-code-of-conduct

--- a/README.md
+++ b/README.md
@@ -114,5 +114,4 @@ We are [available for hire][hire].
 [community]: https://thoughtbot.com/community?utm_source=github
 [hire]: https://thoughtbot.com/hire-us?utm_source=github
 
-
 <!-- END /templates/footer.md -->

--- a/_template/README.md
+++ b/_template/README.md
@@ -16,7 +16,7 @@ This typically takes one of three forms:
 2. Primarily textual sections
 3. A combination of both
 
-## How to...
+## How To Guides
 
 This section, if applicable, should index a list of "How-to" guides for this
 guide's topic. These should be stored relative to this `README.md` file in a

--- a/_template/how-to/do-something-else.md
+++ b/_template/how-to/do-something-else.md
@@ -1,3 +1,3 @@
-## How to Do Something Else
+# How to Do Something Else
 
 This is an example how-to guide. Write anything you want here!

--- a/_template/how-to/do-something.md
+++ b/_template/how-to/do-something.md
@@ -1,3 +1,3 @@
-## How to Do Something
+# How to Do Something
 
 This is an example how-to guide. Write anything you want here!

--- a/code-review/README.md
+++ b/code-review/README.md
@@ -69,7 +69,7 @@ Watch a presentation that covers this material from [Derek Prior at RailsConf 20
   - You may want to consider before/after screenshots or screencasts whenever applicable.
 
 - **Link to the code review from the ticket/story**
-  - "Ready for review: https://github.com/organization/project/pull/1"
+  - "Ready for review: `https://github.com/organization/project/pull/1`
 
 - **Push commits based on earlier rounds of feedback as isolated commits to the branch**
   - Do not squash until the branch is ready to merge.

--- a/data/README.md
+++ b/data/README.md
@@ -24,6 +24,7 @@ A guide for managing a series of tubes.
   messages from different partitions to be processed out of order.
 
 ## Glossary
+
 <dl>
   <dt>Data Engineering</dt>
   <dd>

--- a/data/README.md
+++ b/data/README.md
@@ -174,6 +174,6 @@ A guide for managing a series of tubes.
   <dt>Consumer</dt>
   <dd>An application or process that reads from a data stream.</dd>
 
-  <dt>Producer</dt> 
+  <dt>Producer</dt>
   <dd>An application or process that writes to a data stream.</dd>
 </dl>

--- a/git/README.md
+++ b/git/README.md
@@ -80,7 +80,6 @@ Submit a [GitHub pull request].
 
 Ask for a code review in the project's chat room.
 
-[good commit message]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [use `git rebase` interactively]: https://help.github.com/articles/about-git-rebase/
 [github pull request]: https://help.github.com/articles/using-pull-requests/
 

--- a/git/README.md
+++ b/git/README.md
@@ -54,12 +54,14 @@ git commit --verbose
 
 Write a [good commit message]. Example format:
 
-    Present-tense summary under 50 characters
+```text
+Present-tense summary under 50 characters
 
-    - More information about commit (under 72 characters).
-    - More information about commit (under 72 characters).
+- More information about commit (under 72 characters).
+- More information about commit (under 72 characters).
 
-    http://project.management-system.com/ticket/123
+http://project.management-system.com/ticket/123
+```
 
 If you've created more than one commit, [use `git rebase` interactively] to squash them into cohesive commits with good
 messages:

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -65,3 +65,4 @@ be used.
 - Avoid returning null from operations. [#630]
 
 [graphql specification]: https://graphql.github.io/graphql-spec/
+[#630]: https://github.com/thoughtbot/guides/pull/630

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -27,11 +27,11 @@
 
 - Use [Prettier defaults](https://prettier.io/docs/en/options.html) with the following additional configuration (.prettierrc):
 
-	```json
-	{
-	  "singleQuote": true
-	}
-	```
+  ```json
+  {
+    "singleQuote": true
+  }
+  ```
   
   This configuration includes:
   - Use semicolons at the end of each statement ([sample](/javascript/sample.js#L5))

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -36,8 +36,8 @@
   This configuration includes:
   - Use semicolons at the end of each statement ([sample](/javascript/sample.js#L5))
   - Prefer single quotes ([sample](/javascript/sample.js#L11))
-  - Use a trailing comma after each item in a multi-line array or object literal, including the last item. ([sample](/javascript/sample.js#L11)) 
- 
+  - Use a trailing comma after each item in a multi-line array or object literal, including the last item. ([sample](/javascript/sample.js#L11))
+
 If ESLint is used along with Prettier, the ESLInt plugin [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) should also be used to turn off all ESLint style rules that are already handled by Prettier.
 
 

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -40,7 +40,6 @@
 
 If ESLint is used along with Prettier, the ESLInt plugin [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) should also be used to turn off all ESLint style rules that are already handled by Prettier.
 
-
 [babel]: https://babeljs.io/
 [eslint]: https://eslint.org/
 [prettier]: https://prettier.io/

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,52 @@
+# EXAMPLE USAGE:
+#
+#   Refer for explanation to following link:
+#   https://lefthook.dev/configuration/
+#
+# pre-push:
+#   jobs:
+#     - name: packages audit
+#       tags:
+#         - frontend
+#         - security
+#       run: yarn audit
+#
+#     - name: gems audit
+#       tags:
+#         - backend
+#         - security
+#       run: bundle audit
+#
+# pre-commit:
+#   parallel: true
+#   jobs:
+#     - run: yarn eslint {staged_files}
+#       glob: "*.{js,ts,jsx,tsx}"
+#
+#     - name: rubocop
+#       glob: "*.rb"
+#       exclude:
+#         - config/application.rb
+#         - config/routes.rb
+#       run: bundle exec rubocop --force-exclusion {all_files}
+#
+#     - name: govet
+#       files: git ls-files -m
+#       glob: "*.go"
+#       run: go vet {files}
+#
+#     - script: "hello.js"
+#       runner: node
+#
+#     - script: "hello.go"
+#       runner: go run
+pre-commit:
+  parallel: true
+  jobs:
+    - name: Lint Markdown
+      glob: "*.md"
+      group:
+        parallel: true
+        jobs:
+          - name: Markdownlint
+            run: npx markdownlint-cli2 {staged_files}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+node = "latest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1170 @@
+{
+  "name": "guides",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "guides",
+      "dependencies": {
+        "markdownlint-cli2": "^0.17.2"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.1.0.tgz",
+      "integrity": "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
+        "ignore": "^5.2.4",
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
+    "node_modules/katex": {
+      "version": "0.16.21",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.21.tgz",
+      "integrity": "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.37.4",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.37.4.tgz",
+      "integrity": "sha512-u00joA/syf3VhWh6/ybVFkib5Zpj2e5KB/cfCei8fkSRuums6nyisTWGqjTWIOFoFwuXoTBQQiqlB4qFKp8ncQ==",
+      "license": "MIT",
+      "dependencies": {
+        "markdown-it": "14.1.0",
+        "micromark": "4.0.1",
+        "micromark-core-commonmark": "2.0.2",
+        "micromark-extension-directive": "3.0.2",
+        "micromark-extension-gfm-autolink-literal": "2.1.0",
+        "micromark-extension-gfm-footnote": "2.1.0",
+        "micromark-extension-gfm-table": "2.1.0",
+        "micromark-extension-math": "3.1.0",
+        "micromark-util-types": "2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.17.2.tgz",
+      "integrity": "sha512-XH06ZOi8wCrtOSSj3p8y3yJzwgzYOSa7lglNyS3fP05JPRzRGyjauBb5UvlLUSCGysMmULS1moxdRHHudV+g/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "globby": "14.0.2",
+        "js-yaml": "4.1.0",
+        "jsonc-parser": "3.3.1",
+        "markdownlint": "0.37.4",
+        "markdownlint-cli2-formatter-default": "0.0.5",
+        "micromatch": "4.0.8"
+      },
+      "bin": {
+        "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2-formatter-default": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.5.tgz",
+      "integrity": "sha512-4XKTwQ5m1+Txo2kuQ3Jgpo/KmnG+X90dWt4acufg6HVGadTUG5hzHF/wssp9b5MBYOMCnZ9RMPaU//uHsszF8Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      },
+      "peerDependencies": {
+        "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.1.tgz",
+      "integrity": "sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.2.tgz",
+      "integrity": "sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
+      "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.0.tgz",
+      "integrity": "sha512-Ub2ncQv+fwD70/l4ou27b4YzfNaCJOvyX4HxXU15m7mpYY+rjuWzsLIPZHJL253Z643RpbcP1oeIJlQ/SKW67g==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.1.tgz",
+      "integrity": "sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
       "name": "guides",
       "dependencies": {
         "markdownlint-cli2": "^0.17.2"
+      },
+      "devDependencies": {
+        "lefthook": "^1.11.3"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -389,6 +392,169 @@
       "bin": {
         "katex": "cli.js"
       }
+    },
+    "node_modules/lefthook": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.11.3.tgz",
+      "integrity": "sha512-HJp37y62j3j8qzAOODWuUJl4ysLwsDvCTBV6odr3jIRHR/a5e+tI14VQGIBcpK9ysqC3pGWyW5Rp9Jv1YDubyw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "1.11.3",
+        "lefthook-darwin-x64": "1.11.3",
+        "lefthook-freebsd-arm64": "1.11.3",
+        "lefthook-freebsd-x64": "1.11.3",
+        "lefthook-linux-arm64": "1.11.3",
+        "lefthook-linux-x64": "1.11.3",
+        "lefthook-openbsd-arm64": "1.11.3",
+        "lefthook-openbsd-x64": "1.11.3",
+        "lefthook-windows-arm64": "1.11.3",
+        "lefthook-windows-x64": "1.11.3"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.11.3.tgz",
+      "integrity": "sha512-IYzAOf8Qwqk7q+LoRyy7kSk9vzpUZ5wb/vLzEAH/F86Vay9AUaWe1f2pzeLwFg18qEc1QNklT69h9p/uLQMojA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.11.3.tgz",
+      "integrity": "sha512-z/Wp7UMjE1Vyl+x9sjN3NvN6qKdwgHl+cDf98MKKDg/WyPE5XnzqLm9rLLJgImjyClfH7ptTfZxEyhTG3M3XvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.11.3.tgz",
+      "integrity": "sha512-QevwQ7lrv5wBCkk7LLTzT5KR3Bk/5nttSxT1UH2o0EsgirS/c2K5xSgQmV6m3CiZYuCe2Pja4BSIwN3zt17SMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.11.3.tgz",
+      "integrity": "sha512-PYbcyNgdJJ4J2pEO9Ss4oYo5yq4vmQGTKm3RTYbRx4viSWR65hvKCP0C4LnIqspMvmR05SJi2bqe7UBP2t60EA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.11.3.tgz",
+      "integrity": "sha512-0pBMBAoafOAEg345eOPozsmRjWR0zCr6k+m5ZxwRBZbZx1bQFDqBakQ3TpFCphhcykmgFyaa1KeZJZUOrEsezA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.11.3.tgz",
+      "integrity": "sha512-eiezheZ/bisBCMB2Ur0mctug/RDFyu39B5wzoE8y4z0W1yw6jHGrWMJ4Y8+5qKZ7fmdZg+7YPuMHZ2eFxOnhQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.11.3.tgz",
+      "integrity": "sha512-DRLTzXdtCj/TizpLcGSqXcnrqvgxeXgn/6nqzclIGqNdKCsNXDzpI0D3sP13Vwwmyoqv2etoTak2IHqZiXZDqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.11.3.tgz",
+      "integrity": "sha512-l7om+ZjWpYrVZyDuElwnucZhEqa7YfwlRaKBenkBxEh2zMje8O6Zodeuma1KmyDbSFvnvEjARo/Ejiot4gLXEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.11.3.tgz",
+      "integrity": "sha512-X0iTrql2gfPAkU2dzRwuHWgW5RcqCPbzJtKQ41X6Y/F7iQacRknmuYUGyC81funSvzGAsvlusMVLUvaFjIKnbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.11.3.tgz",
+      "integrity": "sha512-F+ORMn6YJXoS0EXU5LtN1FgV4QX9rC9LucZEkRmK6sKmS7hcb9IHpyb7siRGytArYzJvXVjPbxPBNSBdN4egZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/linkify-it": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "dependencies": {
     "markdownlint-cli2": "^0.17.2"
   },
-  "scripts" : {
+  "scripts": {
     "lint": "markdownlint-cli2 \"./**/*.md\""
+  },
+  "devDependencies": {
+    "lefthook": "^1.11.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "guides",
+  "description": "[![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/thoughtbot/guides.git"
+  },
+  "bugs": {
+    "url": "https://github.com/thoughtbot/guides/issues"
+  },
+  "homepage": "https://github.com/thoughtbot/guides#readme",
+  "dependencies": {
+    "markdownlint-cli2": "^0.17.2"
+  },
+  "scripts" : {
+    "lint": "markdownlint-cli2 \"./**/*.md\""
+  }
+}

--- a/rails/README.md
+++ b/rails/README.md
@@ -130,7 +130,7 @@ others' Rails work, look in particular for:
 
 [ActiveStorage]: https://guides.rubyonrails.org/active_storage_overview.html
 
-## How to...
+## How To Guides
 
 - [Start a New Rails App](./how-to/start_a_new_rails_app.md)
 - [Deploy a Rails App to Heroku](./how-to/deploy_a_rails_app_to_heroku.md)

--- a/rails/how-to/start_a_new_rails_app.md
+++ b/rails/how-to/start_a_new_rails_app.md
@@ -3,11 +3,11 @@
 Use [Suspenders]:
 
 ```sh
-$ gem install suspenders
-$ suspenders the-name-of-your-project-here
-$ cd the-name-of-your-project-here/
-$ bin/setup
-$ rake
+gem install suspenders
+suspenders the-name-of-your-project-here
+cd the-name-of-your-project-here/
+bin/setup
+rake
 ```
 
 [suspenders]: https://github.com/thoughtbot/suspenders

--- a/react-native/README.md
+++ b/react-native/README.md
@@ -8,19 +8,19 @@
 
 ## Tooling
 
-* Start new projects with [create-belt-app](https://www.npmjs.com/package/create-belt-app)
-* Use [Expo](https://expo.dev)
-* Use [Expo EAS](https://expo.dev/eas) for continuous deployment
-* Use [Expo Secure Store](https://docs.expo.dev/versions/latest/sdk/securestore/) for storing sensitive data like auth and refresh tokens
-* Use [React Navigation](https://reactnavigation.org/) for routing
-* Use [TanStack React Query](https://tanstack.com/query/v4/docs/framework/react/overview) as an API client for REST APIs
-* Use [Apollo Client](https://www.apollographql.com/docs/react/) as an API client for GraphQL APIs
-* Use [Redux Toolkit](https://redux-toolkit.js.org/) for global state
-  * Avoid storing API data in a global store. Instead, use a dedicated API client.
-* Use [React Native Firebase](https://rnfirebase.io/) for push notifications
-* Use [Sentry](https://docs.sentry.io/platforms/react-native/) for error reporting
-* Prefer [RevenueCat](https://www.revenuecat.com/) for in-app payments
-  * If RevenueCat pricing is not acceptable since it collects a percentage of revenue, use [react-native-iap](https://react-native-iap.dooboolab.com/docs/get-started/)
+- Start new projects with [create-belt-app](https://www.npmjs.com/package/create-belt-app)
+- Use [Expo](https://expo.dev)
+- Use [Expo EAS](https://expo.dev/eas) for continuous deployment
+- Use [Expo Secure Store](https://docs.expo.dev/versions/latest/sdk/securestore/) for storing sensitive data like auth and refresh tokens
+- Use [React Navigation](https://reactnavigation.org/) for routing
+- Use [TanStack React Query](https://tanstack.com/query/v4/docs/framework/react/overview) as an API client for REST APIs
+- Use [Apollo Client](https://www.apollographql.com/docs/react/) as an API client for GraphQL APIs
+- Use [Redux Toolkit](https://redux-toolkit.js.org/) for global state
+  - Avoid storing API data in a global store. Instead, use a dedicated API client.
+- Use [React Native Firebase](https://rnfirebase.io/) for push notifications
+- Use [Sentry](https://docs.sentry.io/platforms/react-native/) for error reporting
+- Prefer [RevenueCat](https://www.revenuecat.com/) for in-app payments
+  - If RevenueCat pricing is not acceptable since it collects a percentage of revenue, use [react-native-iap](https://react-native-iap.dooboolab.com/docs/get-started/)
 
 ## Style
 

--- a/react-native/README.md
+++ b/react-native/README.md
@@ -42,4 +42,3 @@
 - Use [detox] for integration tests.
 
 [detox]: https://github.com/wix/Detox
-

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -93,10 +93,9 @@
   provider of the API, write [system specs]. Otherwise write [request specs].
 
 [http api design guide]: https://github.com/interagent/http-api-design
-[oj]: https://github.com/ohler55/oj
 [system specs]: https://web.archive.org/web/20230131005307/https://relishapp.com/rspec/rspec-rails/docs/system-specs/system-spec
 [request specs]: https://web.archive.org/web/20221207001104/https://www.relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec
 
-## How to...
+## How To Guides
 
 - [Release a Ruby gem](./how-to/release_a_ruby_gem.md)

--- a/security/application.md
+++ b/security/application.md
@@ -342,7 +342,7 @@ anyone with your private key). The Debian package system is built around this.
 SSH defaults to a trust-on-first-use (TOFU) policy: the first time you connect
 to a server you are asked to confirm the server's public key fingerprint:
 
-```
+```text
 The authenticity of host heroku.com can't be established.
 RSA key fingerprint is 8tF0wX2WquK45aGKs/Bh1dKmBXH08vxUe0VCJJWOA/o.
 Are you sure you want to continue connecting (yes/no)?


### PR DESCRIPTION
- Adds `markdownlint-cli2` to lint the markdown files
- configures markdownlint options
- fixes several minor issues and normalizes style to be consistent
- adds `lefthook` and a pre-commit hook to run markdownlint on staged changes