### PR TITLE
Remove CoffeeScript guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ programming in style.
 ### Languages
 
 - [Bash](/bash/)
-- [CoffeeScript](/coffeescript/)
 - [CSS](/css/)
 - [Elixir](/elixir/)
 - [ERB](/erb/)

--- a/coffeescript/README.md
+++ b/coffeescript/README.md
@@ -1,3 +1,0 @@
-# CoffeeScript
-
-Prefer ES6 or [TypeScript](/typescript/) to CoffeeScript.


### PR DESCRIPTION
We'd no longer use CoffeeScript, preferring to use standard JavaScript or perhaps TypeScript.