### PR TITLE
🗑️ Drop HoundCI references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Guides
 
-[![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
-
 Guides for working together, getting things done, programming well, and
 programming in style.
 

--- a/general/README.md
+++ b/general/README.md
@@ -14,10 +14,8 @@ Style and best practices that apply to all languages and frameworks.
 
 ## Code Review
 
-Use [Hound] to automatically review your GitHub pull requests for style guide
+Use a linter to automatically review your GitHub pull requests for style guide
 violations.
-
-[hound]: https://houndci.com
 
 ## Formatting
 


### PR DESCRIPTION
Before, we used to use HoundCI for all our linting needs. Nowadays we tend to use local linting solutions and CI services. We dropped references to HoundCI from the guides.
