### PR TITLE
Start recommending baseline feature support

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -3,4 +3,7 @@
 - Avoid rendering delays caused by synchronous loading.
 - Use HTTPS instead of HTTP when linking to assets.
 - Prefer using a UTF-8 charset
-- Avoid supporting versions of Internet Explorer before IE11.
+- Avoid targeting specific browsers and aim for [baseline feature support] 
+  which means that features are widely available across major browsers.
+
+[baseline feature support]: https://web-platform-dx.github.io/web-features/


### PR DESCRIPTION
Instead of targeting particular browser versions, we should aim to use browser features which are widely supported across major browsers in use. This allows us to balance using new web functionality, whilst avoiding maintaining lists of supported versions.

For example, as of 2025-03-28, CSS Grid Layout (level 1) is marked at widely available on caniuse.com.

https://web.dev/baseline/
https://web-platform-dx.github.io/web-features/
https://caniuse.com/css-grid