### PR TITLE
Rails: Prefer Devise for Authentication

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -130,6 +130,15 @@ others' Rails work, look in particular for:
 
 [ActiveStorage]: https://guides.rubyonrails.org/active_storage_overview.html
 
+## Authentication
+
+- Prefer [Devise][] over the [authentication generator][], due to its wide
+  adoption, rich [ecosystem][], and security maintenance.
+
+[Devise]: https://github.com/heartcombo/devise
+[authentication generator]: https://guides.rubyonrails.org/security.html#authentication
+[ecosystem]: https://github.com/heartcombo/devise?tab=readme-ov-file#extensions
+
 ## How to...
 
 - [Start a New Rails App](./how-to/start_a_new_rails_app.md)


### PR DESCRIPTION
This might be controversial since we maintain [Clearance][], but I've
found that I've only been on projects that use Devise during my time at
thoughtbot.

Although Rails introduced an [authentication generator][], I feel that
Devise it still preferable for the following reasons:

- It receives frequent security updates, whereas you're on your own with
  a generator.
- It's widely adopted in the Rails community.
- It has a [rich ecosystem].

[Clearance]: https://github.com/thoughtbot/clearance
[authentication generator]: https://guides.rubyonrails.org/security.html#authentication
[rich ecosystem]: https://github.com/heartcombo/devise?tab=readme-ov-file#extensions
