### PR TITLE
feat: define thoughtbot rules for AI-enabled IDEs

### DIFF
--- a/rails/ai-rules/rails-rules.md
+++ b/rails/ai-rules/rails-rules.md
@@ -4,7 +4,7 @@ You are an expert in Ruby on Rails, PostgreSQL, and Hotwire (Turbo and Stimulus)
 
 ## Key Conventions
 
-- Follow RESTful routing conventions: Seven restful actions: index, show, new, create, edit, update, delete (https://thoughtbot.com/blog/in-relentless-pursuit-of-rest-ish-routing)
+- Follow RESTful routing conventions: Seven restful actions: index, show, new, create, edit, update, delete ([thoughtbot post REST-ish routing guide](https://thoughtbot.com/blog/in-relentless-pursuit-of-rest-ish-routing))
 - Prefer classes to modules when designing functionality that is shared by multiple models.
 
 ## Data / Models
@@ -20,14 +20,12 @@ You are an expert in Ruby on Rails, PostgreSQL, and Hotwire (Turbo and Stimulus)
 
 - Always check for N+1 queries when rendering collections
 - Prefer includes for eager loading
-- Scope queries to only the fields needed with select
 
 ## Testing
 
 - Always write tests to cover new code generated
 - Use RSpec for testing framework, unless the project already uses minitest
-- Use factories (FactoryBot) (https://thoughtbot.github.io/factory_bot/)
+- Use factories ([FactoryBot](https://thoughtbot.github.io/factory_bot/))
 - In tests, avoid lets and before (avoid mystery guests), do test setup within each test
 - Verify new code by running test files using `bundle exec rspec spec/path/to/file_spec.rb`
 - You can run a specific test by appending the line number (it can be any line number starting from the "it" block of the test) eg. `bundle exec rspec spec/path/to/file_spec.rb:72`
-  


### PR DESCRIPTION
During a Fusion AI task force meeting, we discussed the tools we use and how we enforce rules. As part of that conversation, we decided it would be valuable to define official thoughtbot guidelines for editors that integrate AI, such as Cursor.

This PR opens the discussion by proposing an initial set of rules. This guide is a starting point for how we write and structure Rails apps at thoughtbot. It’s intended as a starting point to ensure consistency, readability, and shared best practices across our codebases. The guide is a living document it. 