### PR TITLE
Remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ programming in style.
 ### Frameworks and platforms
 
 - [Android](/android/)
-- [Ember](/ember/)
 - [iOS](/ios/)
 - [Rails](/rails/)
 - [React](/react/)


### PR DESCRIPTION
I saw that we still link to the ember guides in the main readme, but we've removed those guides. Here I remove the link in the readme as well.