### PR TITLE
Improve the accessibility guide

### DIFF
--- a/accessibility/README.md
+++ b/accessibility/README.md
@@ -140,7 +140,6 @@ Automated checks can catch a lot of common issues before they reach production.
 [wcag-4-1-2]: https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html
 [wcag-4-1-3]: https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html
 [wcag-1-4-10]: https://www.w3.org/WAI/WCAG22/Understanding/reflow.html
-[wcag-1-3-1]: https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html
 [wcag-2-1-1]: https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html
 [wcag-2-4-3]: https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html
 [wcag-2-4-1]: https://www.w3.org/WAI/WCAG22/Understanding/bypass-blocks.html


### PR DESCRIPTION
- fixed broken links
- mention some good browser extensions for testing
- mention Capybara accessibility tools
- suggest using role selectors in testing
- suggest validating HTML and announcing content changes
- link to WCAG guidelines and supporting documentation

There are a few goals here:
- Add some missing guidelines
- Link to more tools - especially thoughtbot-supported tools like CapybaraAccessibilityAudit
- Give context to the recommendations. Some developers are unfamiliar with accessibility terminology ("focus traps", etc) or how disabled users are affected. These link help give more context and often give concrete examples of how and why to implement a recommendation.