### PR TITLE
update ai-rules README

### DIFF
--- a/rails/ai-rules/README.md
+++ b/rails/ai-rules/README.md
@@ -5,8 +5,8 @@ and other standards.
 
 > **Usage:**
 >
-> 1. Copy the content of this file.
+> 1. Copy the content of the `./CLAUDE.md` file.
 > 2. Create a new file in the root of your project called `.claude/CLAUDE.md`.
 > 3. Update the information in the new file to match your project.
-> 4. Paste the content of this file into the new file.
+> 4. Paste the content of the `./CLAUDE.md` file into the new file.
 > 5. Copy the rules folder into `.claude/`


### PR DESCRIPTION
## Summary

The contents of this `README.md` file used to live in `./CLAUDE.md`. Therefore, when the instructions referenced "this file", it correctly referred to `CLAUDE.md`. Since these instructions have been moved into `README.md`, this commit fixes the instructions to properly reference `./CLAUDE.md`.

See: https://github.com/thoughtbot/guides/pull/789/changes